### PR TITLE
fix(html): render D3 graph instead of a blank page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to Semantic Versioning.
 ### Fixed
 
 - HTML visualization rendered a blank page: D3 `forceLink` threw on import/data-flow endpoints that had no node, and the simulation never ticked positions onto the SVG
+- HTML threw `TypeError: e is not iterable` on load: D3 v7 `scaleOrdinal(null, palette)` iterates a null domain; use `scaleOrdinal(palette)` as the range
 - HTML visualization did not initialize: `initGraph` was never called on page load, and a recursive self-call could hang the page
 - `--ast` computed import edges then discarded them; cycle detection ran on LLM edges without SLOC-based risk scores
 - `--no-html` still wrote `graph.html` when `-o` was set (HTML was written twice)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to Semantic Versioning.
 
 ### Fixed
 
+- HTML visualization rendered a blank page: D3 `forceLink` threw on import/data-flow endpoints that had no node, and the simulation never ticked positions onto the SVG
 - HTML visualization did not initialize: `initGraph` was never called on page load, and a recursive self-call could hang the page
 - `--ast` computed import edges then discarded them; cycle detection ran on LLM edges without SLOC-based risk scores
 - `--no-html` still wrote `graph.html` when `-o` was set (HTML was written twice)

--- a/graphlm/_html_template.html
+++ b/graphlm/_html_template.html
@@ -87,9 +87,10 @@
 <script>
 const graphData = {EMBEDDED_JSON};
 const _PALETTE = {_PALETTE};
-const colorScale = d3.scaleOrdinal(null, _PALETTE);
+const colorScale = d3.scaleOrdinal(_PALETTE);
 function nodeColor(d) {
-  const parts = d.path.split('/');
+  const raw = d.path || d.name || '';
+  const parts = raw.split('/');
   const dir = parts.length > 1 ? parts.slice(0, -1).join('/') : parts[0];
   return colorScale(dir);
 }

--- a/graphlm/_html_template.html
+++ b/graphlm/_html_template.html
@@ -142,15 +142,24 @@ function initGraph() {
   const container = document.getElementById('graph');
   const width = container.clientWidth || 1200;
   const height = container.clientHeight || 800;
-  const links = graphData.links.map((l, i) => ({...l, id: 'link_' + i}));
-  const nodeMap = {};
-  graphData.nodes.forEach(n => { nodeMap[n.path] = n; });
-  links.forEach(l => {
-    l.source = nodeMap[l.source] || l.source;
-    l.target = nodeMap[l.target] || l.target;
+  const nodes = graphData.nodes || [];
+  nodes.forEach(n => { n.id = n.id || n.path || n.name; });
+  const nodeById = new Map();
+  nodes.forEach(n => {
+    nodeById.set(n.id, n);
+    if (n.path) nodeById.set(n.path, n);
   });
-  const simulation = d3.forceSimulation(graphData.nodes)
-    .force('link', d3.forceLink(links).id(d => d.path).distance(80))
+  // Pre-resolve to node objects and drop unknown endpoints. D3 forceLink
+  // throws "node not found" if a link id is missing, which blanked the graph.
+  const links = [];
+  (graphData.links || []).forEach((l, i) => {
+    const s = nodeById.get(l.source);
+    const t = nodeById.get(l.target);
+    if (!s || !t) return;
+    links.push({...l, id: 'link_' + i, source: s, target: t});
+  });
+  const simulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink(links).distance(80))
     .force('charge', d3.forceManyBody().strength(-200))
     .force('center', d3.forceCenter(width / 2, height / 2))
     .force('collision', d3.forceCollide().radius(d => d.r + 8))
@@ -167,7 +176,7 @@ function initGraph() {
     .attr('stroke', d => d.stroke || '#888')
     .attr('stroke-dasharray', d => d.dash || null)
     .attr('stroke-opacity', 0.5);
-  const node = g.append('g').selectAll('g').data(graphData.nodes)
+  const node = g.append('g').selectAll('g').data(nodes)
     .join('g').attr('class', 'node');
   node.each(function(d) {
     const sel = d3.select(this);
@@ -184,15 +193,26 @@ function initGraph() {
         .attr('stroke', '#fff').attr('stroke-width', 1.5)
         .attr('stroke-opacity', 0.3);
     }
-  });
-  const labels = g.append('g').selectAll('text')
-    .data(graphData.nodes.filter(d => d.r >= 8)).join('text')
-    .attr('class', 'label')
-    .attr('dy', d => d.r + 12)
-    .text(d => {
+    if (d.r >= 8) {
       const parts = (d.name || d.path).split('.');
-      return parts.length > 1 ? parts[parts.length - 1] : (d.name || '');
-    }).attr('opacity', 0.7);
+      sel.append('text')
+        .attr('class', 'label')
+        .attr('dy', d.r + 12)
+        .text(parts.length > 1 ? parts[parts.length - 1] : (d.name || ''))
+        .attr('opacity', 0.7);
+    }
+  });
+  const labels = node.selectAll('text.label');
+  simulation.on('tick', () => {
+    link.attr('d', d => {
+      if (d.source.x == null || d.target.x == null) return null;
+      const x1 = d.source.x, y1 = d.source.y, x2 = d.target.x, y2 = d.target.y;
+      const dx = x2 - x1, dy = y2 - y1;
+      const dr = Math.hypot(dx, dy) || 1;
+      return 'M' + x1 + ',' + y1 + 'A' + dr + ',' + dr + ' 0 0,1 ' + x2 + ',' + y2;
+    });
+    node.attr('transform', d => 'translate(' + (d.x ?? 0) + ',' + (d.y ?? 0) + ')');
+  });
   const tooltip = d3.select('#tooltip');
   node.on('mouseover', function(event, d) {
     tooltip.style('display', 'block').html(

--- a/graphlm/html_render.py
+++ b/graphlm/html_render.py
@@ -24,41 +24,108 @@ def _directory_color(dir_name: str) -> str:
     return _PALETTE[idx]
 
 
+_TYPE_RANK = {
+    "entry_point": 3,
+    "module": 2,
+    "file_summary": 1,
+    "file": 0,
+    "component": 0,
+}
+
+
+def _upsert_node(
+    by_id: dict[str, dict[str, Any]],
+    key: str,
+    *,
+    name: str,
+    type: str,
+    path: str,
+    description: str,
+    r: int,
+) -> None:
+    """Insert or merge a node. One node per id so D3 forceLink can resolve links."""
+    existing = by_id.get(key)
+    if existing is None:
+        by_id[key] = {
+            "id": key,
+            "name": name,
+            "type": type,
+            "path": path,
+            "description": description,
+            "r": r,
+            "color": _directory_color(path),
+        }
+        return
+    if _TYPE_RANK.get(type, 0) > _TYPE_RANK.get(existing["type"], 0):
+        existing["type"] = type
+        existing["name"] = name or existing["name"]
+    if r > existing["r"]:
+        existing["r"] = r
+    if description and (
+        not existing["description"] or len(description) > len(existing["description"])
+    ):
+        existing["description"] = description
+
+
 def _build_nodes(graph: CodebaseGraph) -> list[dict[str, Any]]:
-    """Build D3 node data from the graph."""
-    nodes: list[dict[str, Any]] = []
+    """Build D3 node data from the graph.
+
+    One node per file path (or data-flow label). Import-edge and data-flow
+    endpoints that are not already modules/entry points/summaries are added
+    so every link can resolve — D3 forceLink throws on missing node ids.
+    """
+    by_id: dict[str, dict[str, Any]] = {}
 
     for mod in graph.modules:
-        nodes.append({
-            "name": mod.name,
-            "type": "module",
-            "path": mod.path,
-            "description": mod.description,
-            "r": 8,
-            "color": _directory_color(mod.path),
-        })
-
+        _upsert_node(
+            by_id,
+            mod.path,
+            name=mod.name,
+            type="module",
+            path=mod.path,
+            description=mod.description,
+            r=8,
+        )
     for ep in graph.entry_points:
-        nodes.append({
-            "name": ep.name,
-            "type": "entry_point",
-            "path": ep.path,
-            "description": ep.description,
-            "r": 12,
-            "color": _directory_color(ep.path),
-        })
-
+        _upsert_node(
+            by_id,
+            ep.path,
+            name=ep.name,
+            type="entry_point",
+            path=ep.path,
+            description=ep.description,
+            r=12,
+        )
     for fs in graph.file_summaries:
-        nodes.append({
-            "name": fs.path,
-            "type": "file_summary",
-            "path": fs.path,
-            "description": fs.summary,
-            "r": 5,
-            "color": _directory_color(fs.path),
-        })
+        _upsert_node(
+            by_id,
+            fs.path,
+            name=fs.path,
+            type="file_summary",
+            path=fs.path,
+            description=fs.summary,
+            r=5,
+        )
+    for edge in graph.import_edges:
+        for p in (edge.from_path, edge.to_path):
+            if p not in by_id:
+                _upsert_node(
+                    by_id, p, name=p, type="file", path=p, description="", r=6
+                )
+    for flow in graph.data_flow:
+        for p in (flow.source, flow.destination):
+            if p not in by_id:
+                _upsert_node(
+                    by_id,
+                    p,
+                    name=p,
+                    type="component",
+                    path=p,
+                    description=flow.description,
+                    r=7,
+                )
 
-    return nodes
+    return list(by_id.values())
 
 
 def _build_links(graph: CodebaseGraph) -> list[dict[str, Any]]:

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -353,6 +353,13 @@ class TestRenderHtml:
         assert "simulation.on('tick'" in html
         assert "translate(" in html
 
+    def test_scale_ordinal_does_not_pass_null_domain(self):
+        """D3 v7 iterates the domain; scaleOrdinal(null, range) throws 'e is not iterable'."""
+        graph = CodebaseGraph(directory_tree="test/")
+        html = render_html(graph)
+        assert "scaleOrdinal(null" not in html
+        assert "scaleOrdinal(_PALETTE)" in html
+
     def test_rendered_links_all_resolve_to_nodes(self):
         graph = CodebaseGraph(
             directory_tree="root/",

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -125,6 +125,46 @@ class TestBuildNodes:
         nodes = _build_nodes(graph)
         assert nodes[0]["path"] == "lib/utils.py"
 
+    def test_duplicate_path_collapsed_to_one_node(self):
+        graph = CodebaseGraph(
+            directory_tree="root/",
+            modules=[ModuleDescription(path="app/main.py", name="App", description="Factory")],
+            entry_points=[
+                {
+                    "path": "app/main.py",
+                    "name": "main",
+                    "kind": "main",
+                    "description": "CLI",
+                }
+            ],
+            file_summaries=[FileSummary(path="app/main.py", summary="The main module")],
+        )
+        nodes = _build_nodes(graph)
+        assert len(nodes) == 1
+        assert nodes[0]["type"] == "entry_point"
+        assert nodes[0]["r"] == 12
+        assert nodes[0]["id"] == "app/main.py"
+
+    def test_import_edge_endpoints_become_nodes(self):
+        graph = CodebaseGraph(
+            directory_tree="root/",
+            import_edges=[
+                ImportEdge(from_path="tests/test_cli.py", to_path="graphlm/cli.py", kind="import"),
+            ],
+        )
+        nodes = _build_nodes(graph)
+        ids = {n["id"] for n in nodes}
+        assert ids == {"tests/test_cli.py", "graphlm/cli.py"}
+
+    def test_data_flow_endpoints_become_nodes(self):
+        graph = CodebaseGraph(
+            directory_tree="root/",
+            data_flow=[{"source": "CLI (cli.py)", "destination": "Library API", "description": "calls"}],
+        )
+        nodes = _build_nodes(graph)
+        ids = {n["id"] for n in nodes}
+        assert ids == {"CLI (cli.py)", "Library API"}
+
 
 class TestBuildLinks:
     def test_import_edges_become_links(self):
@@ -306,6 +346,33 @@ class TestRenderHtml:
         graph = CodebaseGraph(directory_tree="test/")
         html = render_html(graph)
         assert "d3.zoom" in html
+
+    def test_html_contains_tick_handler(self):
+        graph = CodebaseGraph(directory_tree="test/")
+        html = render_html(graph)
+        assert "simulation.on('tick'" in html
+        assert "translate(" in html
+
+    def test_rendered_links_all_resolve_to_nodes(self):
+        graph = CodebaseGraph(
+            directory_tree="root/",
+            modules=[ModuleDescription(path="graphlm/cli.py", name="cli", description="CLI")],
+            import_edges=[
+                ImportEdge(from_path="tests/test_cli.py", to_path="graphlm/cli.py", kind="import"),
+            ],
+            data_flow=[
+                {"source": "CLI (cli.py)", "destination": "Library API", "description": "invokes"},
+            ],
+        )
+        html = render_html(graph)
+        data = json.loads(
+            html[html.index("const graphData = ") + len("const graphData = "):html.index(";\nconst _PALETTE")]
+        )
+        ids = {n["id"] for n in data["nodes"]} | {n["path"] for n in data["nodes"]}
+        assert data["links"]
+        for link in data["links"]:
+            assert link["source"] in ids
+            assert link["target"] in ids
 
     def test_file_summaries_with_symbols(self):
         graph = CodebaseGraph(


### PR DESCRIPTION
## Summary

The HTML visualization opened as a blank page. Two D3 failures aborted `initGraph` before any SVG was drawn: `scaleOrdinal(null, palette)` throws `TypeError: e is not iterable` in D3 v7, and `forceLink` threw `node not found` for import/data-flow endpoints that had no node. Positions were also never ticked onto the SVG.

## What changed and why

- `d3.scaleOrdinal(_PALETTE)` — pass the palette as the range only; a null domain is not iterable in D3 v7.
- Emit a node for every import-edge and data-flow endpoint; collapse duplicate paths to one node so `forceLink` can resolve ids.
- Skip unresolved links instead of throwing.
- Tick handler writes node `transform` and link path `d`.

The `file://` unique-origin console warning is Chrome treating preview iframes as a different origin from the same path. This HTML has no iframe; open the file in a normal tab (or serve it) if that warning appears.

## Verification

- `uv run pytest` — **255 passed**
- Reproduced `scaleOrdinal(null, range)` → `TypeError: e is not iterable` with `d3.v7.min.js`; `scaleOrdinal(range)` succeeds
- Against the dogfood `graphs.json`: 34 nodes, 50/50 links resolved, force simulation assigns positions with no throw

## Post-merge

Re-run `graphlm` (or re-render HTML from existing JSON) to pick up the template change in already-generated `graph.html` files.