### PR TITLE
feat: write GRAPH.md/json/html and enable AST parsing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to Semantic Versioning.
 
 ### Changed
 
+- Output files are `GRAPH.md`, `GRAPH.json`, and `GRAPH.html` (were `graphs.md` / `graphs.json` / `graph.html`)
+- AST import parsing is on by default; pass `--no-ast` or `ast=False` to skip. The `--ast` flag is removed
 - `GraphResult.write()` now returns `tuple[Path, Path, Path | None]` (md, json, html_or_none) instead of `tuple[Path, Path]`
 - `write_outputs()` now optionally writes HTML alongside Markdown and JSON
 

--- a/DEMO.md
+++ b/DEMO.md
@@ -11,10 +11,10 @@ The visualization initializes on page load: zoom/pan, node search, and theme tog
 
 ```bash
 graphlm /path/to/project -o ./output
-# Open output/graph.html in a browser
+# Open output/GRAPH.html in a browser
 ```
 
-Pass `--no-html` to skip writing `graph.html`.
+Pass `--no-html` to skip writing `GRAPH.html`.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Given a project directory, graphLM produces a structured analysis as **Markdown*
 - **Architecture notes** — key decisions and patterns
 - **Quick reference** — "where do I find X?" lookups
 - **Import cycles** — strongly-connected components with SLOC-based risk scores
-- **Interactive HTML** — D3 force graph (`graph.html`) with zoom/pan, search, and theme toggle
+- **Interactive HTML** — D3 force graph (`GRAPH.html`) with zoom/pan, search, and theme toggle
 
 ## Installation
 
@@ -47,10 +47,10 @@ graphlm /path/to/project -b https://api.example.com/v1 -k sk-xxx -m my-model
 # Exclude test files and custom patterns
 graphlm /path/to/project --no-tests --exclude __pycache__ --exclude .git
 
-# Deterministic AST import edges (Tree-sitter) alongside the LLM
-graphlm /path/to/project -o ./output --ast
+# Skip Tree-sitter AST import edges
+graphlm /path/to/project -o ./output --no-ast
 
-# Skip writing graph.html
+# Skip writing GRAPH.html
 graphlm /path/to/project -o ./output --no-html
 ```
 
@@ -74,8 +74,8 @@ result = generate_graph(
     api_key="sk-xxx",
     model="Qwen3.6-35B",
     output_dir="./output",
-    ast=True,              # Tree-sitter import edges + SLOC cycle scores
-    include_html=True,     # skip graph.html when False (default: write it)
+    ast=True,              # Tree-sitter import edges + SLOC cycle scores (default)
+    include_html=True,     # skip GRAPH.html when False (default: write it)
     show_cycles=True,      # skip the cycle section when False
     cycle_threshold=0.0,   # min cycle risk score
 )
@@ -83,7 +83,7 @@ result = generate_graph(
 print(len(result.graph.modules), "modules found")
 ```
 
-With `ast=True`, graphLM runs Tree-sitter, attaches `graph.deterministic_edges`, passes those edges into the pass-2 prompt as ground truth, and runs cycle detection on the AST edges with SLOC-based risk scores. `include_html=False` skips writing `graph.html` when `output_dir` is set (HTML is on by default).
+AST parsing is on by default: graphLM runs Tree-sitter, attaches `graph.deterministic_edges`, passes those edges into the pass-2 prompt as ground truth, and runs cycle detection on the AST edges with SLOC-based risk scores. Pass `ast=False` or `--no-ast` to skip. `include_html=False` skips writing `GRAPH.html` when `output_dir` is set (HTML is on by default).
 
 ## How it works
 
@@ -94,7 +94,7 @@ graphLM uses a **two-pass LLM strategy** to stay within context windows while st
 
 This keeps the first pass lightweight (~tree tokens) and ensures the second pass only includes files that matter.
 
-`--ast` is an optional deterministic pass (Tree-sitter Python imports). It does not replace the LLM: the two-pass analysis still runs, and AST edges are extra ground truth plus cycle detection.
+A Tree-sitter pass (Python imports) runs by default. It does not replace the LLM: the two-pass analysis still runs, and AST edges are extra ground truth plus cycle detection. Pass `--no-ast` to skip.
 
 ## Configuration
 
@@ -116,7 +116,7 @@ Settings can also be passed directly via CLI flags (`-b`, `-k`, `-m`) or library
 
 | Flag | Description | Default |
 |---|---|---|
-| `-o, --output-dir` | Output directory for `.md`, `.json`, and `graph.html` | Current directory |
+| `-o, --output-dir` | Output directory for `GRAPH.md`, `GRAPH.json`, and `GRAPH.html` | Current directory |
 | `-b, --base-url` | LLM API base URL | `GRAPHLM_BASE_URL` env var |
 | `-k, --api-key` | LLM API key | `GRAPHLM_API_KEY` env var |
 | `-m, --model` | Model name | `GRAPHLM_MODEL` env var |
@@ -128,8 +128,8 @@ Settings can also be passed directly via CLI flags (`-b`, `-k`, `-m`) or library
 | `--exclude` | Exclude pattern (repeatable) | — |
 | `--no-redact` | Skip secret redaction | Redaction on |
 | `--dry-run` | Show stats without calling LLM | Disabled |
-| `--ast` | AST deterministic import edges (Tree-sitter) | Off |
-| `--no-html` | Do not write `graph.html` | HTML on |
+| `--no-ast` | Skip Tree-sitter AST import edges | AST on |
+| `--no-html` | Do not write `GRAPH.html` | HTML on |
 | `--no-show-cycles` | Skip the cycle section | Cycles on |
 | `--cycle-threshold` | Minimum cycle risk score | 0.0 |
 

--- a/graphlm/__init__.py
+++ b/graphlm/__init__.py
@@ -76,7 +76,7 @@ def generate_graph(
     exclude_patterns: tuple[str, ...] = (),
     dry_run: bool = False,
     redact_secrets: bool = True,
-    ast: bool = False,
+    ast: bool = True,
     show_cycles: bool = True,
     cycle_threshold: float = 0.0,
     include_html: bool = True,
@@ -101,9 +101,10 @@ def generate_graph(
         exclude_patterns: Additional glob patterns to exclude.
         dry_run: If True, return the scan context without calling the LLM.
         redact_secrets: If True, redact secret-like patterns from file content.
-        ast: If True, run AST-based deterministic import detection, attach
-            those edges to the graph, and pass them to the LLM as ground truth.
-        include_html: If output_dir is set, whether to also write graph.html.
+        ast: If True (default), run AST-based deterministic import detection,
+            attach those edges to the graph, and pass them to the LLM as
+            ground truth. Pass False / --no-ast to skip.
+        include_html: If output_dir is set, whether to also write GRAPH.html.
 
     Returns:
         GraphResult with the graph and output metadata.
@@ -145,7 +146,7 @@ def generate_graph(
         redact_secrets=redact_secrets,
     )
 
-    # If --ast is enabled, build deterministic import edges from AST parsing
+    # Deterministic import edges from AST parsing (on by default)
     deterministic_edges: list[ImportEdge] | None = None
     if ast:
         try:

--- a/graphlm/cli.py
+++ b/graphlm/cli.py
@@ -83,15 +83,15 @@ def main(
         "--dry-run",
         help="Analyze and show context stats without calling the LLM.",
     ),
-    ast: bool = typer.Option(
+    no_ast: bool = typer.Option(
         False,
-        "--ast",
-        help="Use Tree-sitter AST parsing for deterministic import edges.",
+        "--no-ast",
+        help="Skip Tree-sitter AST parsing for deterministic import edges.",
     ),
     no_html: bool = typer.Option(
         False,
         "--no-html",
-        help="Do not generate HTML visualization output.",
+        help="Do not generate GRAPH.html visualization output.",
     ),
     no_show_cycles: bool = typer.Option(
         False,
@@ -129,7 +129,7 @@ def main(
             exclude_patterns=tuple(exclude),
             dry_run=dry_run,
             redact_secrets=not no_redact,
-            ast=ast,
+            ast=not no_ast,
             show_cycles=not no_show_cycles,
             cycle_threshold=cycle_threshold,
             include_html=not no_html,

--- a/graphlm/render.py
+++ b/graphlm/render.py
@@ -154,10 +154,10 @@ def write_outputs(
     graph: CodebaseGraph,
     output_dir: Path,
     *,
-    md_suffix: str = "graphs",
-    json_suffix: str = "graphs",
+    md_suffix: str = "GRAPH",
+    json_suffix: str = "GRAPH",
     html: bool = True,
-    html_suffix: str = "graph",
+    html_suffix: str = "GRAPH",
 ) -> tuple[Path, Path, Path | None]:
     """Write Markdown, JSON, and optionally HTML outputs to output_dir.
 

--- a/innovation/DEMO.md
+++ b/innovation/DEMO.md
@@ -58,5 +58,5 @@ Working — all 32 tests pass, 163 total tests pass.
 ## Next increments
 
 - Add JavaScript/TypeScript parsing support (currently returns empty results)
-- Wire `--ast` flag into `generate_graph()` CLI to automatically attach deterministic edges
+- AST parsing is on by default (`--no-ast` to skip)
 - Add caller/callee edge analysis (beyond just imports)

--- a/innovation/feat-ast-parser/DEMO.md
+++ b/innovation/feat-ast-parser/DEMO.md
@@ -30,22 +30,22 @@ cycles = detect_import_cycles(edges)
 ### From the CLI
 
 ```bash
-# Dry run with AST detection
-graphlm /path/to/project --dry-run --ast
+# Dry run (AST is on by default)
+graphlm /path/to/project --dry-run
 
-# Full run with AST detection
-graphlm /path/to/project -o ./output --ast
+# Skip AST parsing
+graphlm /path/to/project -o ./output --no-ast
 ```
 
 ### Integration with graphLM
 
-When `--ast` (or `ast=True`) is enabled, the parser runs after scanning and:
+AST parsing is on by default. After scanning, the parser:
 
 1. Extracts deterministic import edges from all scanned files
 2. Passes those edges to the LLM as ground truth in the pass-2 prompt
 3. Attaches `deterministic_edges` to the output `CodebaseGraph`
 
-`--ast` does not replace the two-pass LLM analysis.
+It does not replace the two-pass LLM analysis. Pass `--no-ast` or `ast=False` to skip.
 
 ## Supported languages
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,12 +68,24 @@ class TestCLI:
         )
         assert result.exit_code == 0
         assert "Dry run complete" in result.stdout or "Dry run complete" in result.stderr
-        assert not (tmp_path / "graph.html").exists()
-        assert not (tmp_path / "graphs.md").exists()
-        assert not (tmp_path / "graphs.json").exists()
+        assert not (tmp_path / "GRAPH.html").exists()
+        assert not (tmp_path / "GRAPH.md").exists()
+        assert not (tmp_path / "GRAPH.json").exists()
 
     def test_dry_run_ast_cyclic_project(self):
         cyclic_project = Path(__file__).parent / "fixtures" / "cyclic_project"
-        result = runner.invoke(app, [str(cyclic_project), "--dry-run", "--ast"])
+        result = runner.invoke(app, [str(cyclic_project), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run complete" in result.stdout or "Dry run complete" in result.stderr
+
+    def test_help_lists_no_ast(self):
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "--no-ast" in result.stdout
+        assert "--ast" not in result.stdout.replace("--no-ast", "")
+
+    def test_dry_run_no_ast(self):
+        cyclic_project = Path(__file__).parent / "fixtures" / "cyclic_project"
+        result = runner.invoke(app, [str(cyclic_project), "--dry-run", "--no-ast"])
         assert result.exit_code == 0
         assert "Dry run complete" in result.stdout or "Dry run complete" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the CLI."""
 
+import re
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -7,6 +8,13 @@ from typer.testing import CliRunner
 from graphlm.cli import app
 
 runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI color codes so flag names are searchable in Rich help."""
+    return _ANSI.sub("", text)
 
 
 class TestCLI:
@@ -81,8 +89,9 @@ class TestCLI:
     def test_help_lists_no_ast(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "--no-ast" in result.stdout
-        assert "--ast" not in result.stdout.replace("--no-ast", "")
+        help_text = _plain(result.stdout)
+        assert "--no-ast" in help_text
+        assert "--ast" not in help_text.replace("--no-ast", "")
 
     def test_dry_run_no_ast(self):
         cyclic_project = Path(__file__).parent / "fixtures" / "cyclic_project"

--- a/tests/test_html_render.py
+++ b/tests/test_html_render.py
@@ -439,7 +439,7 @@ class TestWriteOutputsWithHtml:
             assert json_path.exists()
             assert html_path is not None
             assert html_path.exists()
-            assert html_path.name == "graph.html"
+            assert html_path.name == "GRAPH.html"
             assert html_path.read_text(encoding="utf-8").startswith("<!DOCTYPE")
 
     def test_no_html_when_disabled(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -263,7 +263,7 @@ class TestFullPipeline:
     def test_ast_dry_run_attaches_edges_and_cycles(self):
         """ast=True dry-run keeps parser edges and detects the fixture cycle."""
         cyclic_project = Path(__file__).parent / "fixtures" / "cyclic_project"
-        result = generate_graph(cyclic_project, dry_run=True, ast=True)
+        result = generate_graph(cyclic_project, dry_run=True)
 
         assert result.graph.deterministic_edges is not None
         assert len(result.graph.deterministic_edges) > 0
@@ -277,7 +277,7 @@ class TestFullPipeline:
             assert rel in cycle_nodes or any(n.endswith(rel) for n in cycle_nodes)
 
     def test_include_html_false_skips_html(self, httpx_mock, small_project, tmp_path):
-        """generate_graph with include_html=False must not write graph.html."""
+        """generate_graph with include_html=False must not write GRAPH.html."""
         _mock_pass1_response(httpx_mock, ["main.py", "mylib/helpers.py"])
         _mock_pass2_response(httpx_mock, _make_graph())
 
@@ -290,9 +290,9 @@ class TestFullPipeline:
             include_html=False,
         )
 
-        assert (tmp_path / "graphs.md").exists()
-        assert (tmp_path / "graphs.json").exists()
-        assert not (tmp_path / "graph.html").exists()
+        assert (tmp_path / "GRAPH.md").exists()
+        assert (tmp_path / "GRAPH.json").exists()
+        assert not (tmp_path / "GRAPH.html").exists()
 
     def test_ast_full_pipeline_attaches_deterministic_edges(self, httpx_mock):
         """Mocked pipeline with ast=True attaches parser edges to the graph."""
@@ -307,10 +307,13 @@ class TestFullPipeline:
             base_url="http://test.local/v1",
             api_key="test-key",
             model="test-model",
-            ast=True,
         )
 
         assert result.graph.deterministic_edges is not None
+
+    def test_ast_false_skips_deterministic_edges(self, small_project):
+        result = generate_graph(small_project, dry_run=True, ast=False)
+        assert result.graph.deterministic_edges is None
 
     def test_write_accepts_str_and_returns_three_paths(self, small_project, tmp_path):
         """GraphResult.write accepts str paths and unpacks to md, json, html."""
@@ -322,7 +325,10 @@ class TestFullPipeline:
         assert html_path.exists()
         _, _, no_html = result.write(str(tmp_path / "plain"), include_html=False)
         assert no_html is None
-        assert not (tmp_path / "plain" / "graph.html").exists()
+        assert md_path.name == "GRAPH.md"
+        assert json_path.name == "GRAPH.json"
+        assert html_path.name == "GRAPH.html"
+        assert not (tmp_path / "plain" / "GRAPH.html").exists()
 
     def test_show_cycles_false_leaves_cycles_empty(self):
         cyclic_project = Path(__file__).parent / "fixtures" / "cyclic_project"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -162,8 +162,9 @@ class TestWriteOutputs:
             assert json_path.exists()
             assert html_path is not None
             assert html_path.exists()
-            assert md_path.name.endswith(".md")
-            assert json_path.name.endswith(".json")
+            assert md_path.name == "GRAPH.md"
+            assert json_path.name == "GRAPH.json"
+            assert html_path.name == "GRAPH.html"
 
     def test_no_html_when_disabled(self):
         graph = CodebaseGraph(directory_tree="root/\n")


### PR DESCRIPTION
## Summary

Output files are now `GRAPH.md`, `GRAPH.json`, and `GRAPH.html`. Tree-sitter AST import parsing is on by default so deterministic edges and SLOC-scored cycles are part of a normal run; `--no-ast` / `ast=False` skips it. The old `--ast` flag is removed.

## What changed and why

- Default write names: `GRAPH.md` / `GRAPH.json` / `GRAPH.html` (were `graphs.md` / `graphs.json` / `graph.html`).
- `generate_graph(..., ast=True)` by default. CLI `--no-ast` maps to `ast=False`.
- Docs (README, DEMO, CHANGELOG, AST innovation DEMO) match the new names and default.

AST as default: Tree-sitter is already a runtime dependency, parse cost is negligible next to two LLM passes, and deterministic edges are better ground truth than LLM-only imports. JS/TS parsing is still unimplemented (same as before).

## Verification

- `uv run pytest` — **258 passed**
- `uv run mypy graphlm --ignore-missing-imports` — clean

## Post-merge

Re-run `graphlm` to produce the new filenames. Existing `graphs.md` / `graphs.json` / `graph.html` in a project directory are leftover from earlier runs and are not overwritten under the old names.