### PR TITLE
fix(cli): write GRAPH.* into the scanned project, not cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to Semantic Versioning.
 
 ### Changed
 
+- CLI writes `GRAPH.md` / `GRAPH.json` / `GRAPH.html` into the scanned project directory by default (not the process working directory). `-o` still overrides
 - Output files are `GRAPH.md`, `GRAPH.json`, and `GRAPH.html` (were `graphs.md` / `graphs.json` / `graph.html`)
 - AST import parsing is on by default; pass `--no-ast` or `ast=False` to skip. The `--ast` flag is removed
 - `GraphResult.write()` now returns `tuple[Path, Path, Path | None]` (md, json, html_or_none) instead of `tuple[Path, Path]`

--- a/DEMO.md
+++ b/DEMO.md
@@ -10,8 +10,8 @@ The visualization initializes on page load: zoom/pan, node search, and theme tog
 ## How to try
 
 ```bash
-graphlm /path/to/project -o ./output
-# Open output/GRAPH.html in a browser
+graphlm /path/to/project
+# Open /path/to/project/GRAPH.html in a browser
 ```
 
 Pass `--no-html` to skip writing `GRAPH.html`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ uv pip install -e .
 ### CLI
 
 ```bash
-# Analyze a project and write output files
+# Analyze a project; writes GRAPH.md, GRAPH.json, GRAPH.html into that project
+graphlm /path/to/project
+
+# Write to a different directory
 graphlm /path/to/project -o ./output
 
 # Dry run — see context stats without calling the LLM
@@ -116,7 +119,7 @@ Settings can also be passed directly via CLI flags (`-b`, `-k`, `-m`) or library
 
 | Flag | Description | Default |
 |---|---|---|
-| `-o, --output-dir` | Output directory for `GRAPH.md`, `GRAPH.json`, and `GRAPH.html` | Current directory |
+| `-o, --output-dir` | Output directory for `GRAPH.md`, `GRAPH.json`, and `GRAPH.html` | The scanned project |
 | `-b, --base-url` | LLM API base URL | `GRAPHLM_BASE_URL` env var |
 | `-k, --api-key` | LLM API key | `GRAPHLM_API_KEY` env var |
 | `-m, --model` | Model name | `GRAPHLM_MODEL` env var |

--- a/graphlm/__init__.py
+++ b/graphlm/__init__.py
@@ -92,7 +92,8 @@ def generate_graph(
         base_url: LLM API base URL (falls back to GRAPHLM_BASE_URL env var).
         api_key: LLM API key (falls back to GRAPHLM_API_KEY env var).
         model: Model name (falls back to GRAPHLM_MODEL env var).
-        output_dir: Where to write .md and .json outputs (default: current dir).
+        output_dir: Where to write GRAPH.md/json/html. None means do not write
+            (the CLI defaults to the scanned project directory).
         max_file_chars: Maximum characters to read per file.
         max_files: Maximum files to scan initially.
         max_pass2_files: Maximum files to include in pass 2 context.

--- a/graphlm/cli.py
+++ b/graphlm/cli.py
@@ -13,6 +13,13 @@ app = typer.Typer(
 )
 
 
+def output_destination(project_dir: Path, output_dir: str | None) -> Path:
+    """Directory for GRAPH.* files: -o if given, else the scanned project."""
+    if output_dir:
+        return Path(output_dir)
+    return Path(project_dir)
+
+
 @app.command()
 def main(
     project_dir: Path = typer.Argument(
@@ -23,7 +30,7 @@ def main(
         None,
         "-o",
         "--output-dir",
-        help="Output directory for generated files (default: current directory).",
+        help="Output directory for GRAPH.md/json/html (default: the scanned project).",
     ),
     base_url: str = typer.Option(
         None,
@@ -165,7 +172,7 @@ def main(
         )
         raise typer.Exit(0)
 
-    dest = Path(output_dir) if output_dir else Path.cwd()
+    dest = output_destination(project_dir, output_dir)
     md_path, json_path, html_path = result.write(dest, include_html=not no_html)
     typer.echo(f"Markdown:  {md_path}", err=True)
     typer.echo(f"JSON:      {json_path}", err=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,13 @@
 
 import re
 from pathlib import Path
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
-from graphlm.cli import app
+from graphlm import GraphResult
+from graphlm.cli import app, output_destination
+from graphlm.models import CodebaseGraph
 
 runner = CliRunner()
 
@@ -98,3 +101,66 @@ class TestCLI:
         result = runner.invoke(app, [str(cyclic_project), "--dry-run", "--no-ast"])
         assert result.exit_code == 0
         assert "Dry run complete" in result.stdout or "Dry run complete" in result.stderr
+
+    def test_output_destination_defaults_to_project(self, tmp_path):
+        project = tmp_path / "scanned"
+        other = tmp_path / "elsewhere"
+        assert output_destination(project, None) == project
+        assert output_destination(project, str(other)) == other
+
+    def test_cli_writes_into_scanned_project_not_cwd(
+        self, small_project, tmp_path, monkeypatch
+    ):
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        recorded: dict[str, Path] = {}
+
+        def fake_write(self, output_dir, *, include_html=True):
+            dest = Path(output_dir).resolve()
+            recorded["dest"] = dest
+            md = dest / "GRAPH.md"
+            js = dest / "GRAPH.json"
+            html = dest / "GRAPH.html" if include_html else None
+            return md, js, html
+
+        def fake_generate_graph(**_kwargs):
+            return GraphResult(CodebaseGraph(directory_tree="t/\n"), 1, 1, 1)
+
+        with (
+            patch("graphlm.generate_graph", fake_generate_graph),
+            patch.object(GraphResult, "write", fake_write),
+        ):
+            result = runner.invoke(app, [str(small_project)])
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert recorded["dest"] == small_project.resolve()
+        assert not (cwd / "GRAPH.md").exists()
+
+    def test_cli_dash_o_overrides_project_dir(
+        self, small_project, tmp_path, monkeypatch
+    ):
+        cwd = tmp_path / "cwd"
+        out = tmp_path / "out"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        recorded: dict[str, Path] = {}
+
+        def fake_write(self, output_dir, *, include_html=True):
+            dest = Path(output_dir).resolve()
+            recorded["dest"] = dest
+            md = dest / "GRAPH.md"
+            js = dest / "GRAPH.json"
+            return md, js, None
+
+        def fake_generate_graph(**_kwargs):
+            return GraphResult(CodebaseGraph(directory_tree="t/\n"), 1, 1, 1)
+
+        with (
+            patch("graphlm.generate_graph", fake_generate_graph),
+            patch.object(GraphResult, "write", fake_write),
+        ):
+            result = runner.invoke(app, [str(small_project), "-o", str(out)])
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert recorded["dest"] == out.resolve()


### PR DESCRIPTION
## Summary

Without `-o`, the CLI wrote `GRAPH.md` / `GRAPH.json` / `GRAPH.html` into the process working directory. Running `graphlm /path/to/project` from another folder therefore dropped files next to the tool instead of next to the code being analyzed.

## What changed and why

- Default output destination is the scanned project directory.
- `-o` / `--output-dir` still overrides.
- Library API is unchanged: `generate_graph` only writes when `output_dir` is passed.

## Verification

- `uv run pytest` — **261 passed**
- CLI tests: default dest is the project path; `-o` overrides; cwd is not used

## Post-merge

`graphlm /path/to/project` writes into `/path/to/project/`.