### PR TITLE
fix(skills): distinguish explicit vs mid-task invocation in the agent guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to Semantic Versioning.
 
 ### Changed
 
+- `--install-skill` guide now distinguishes the two invocation modes so an agent doesn't stall or misfire. When it's invoked **explicitly** (the user ran the skill/command directly) and no map exists, the guide says to generate one with `graphlm .` **without asking** — a safe, local, idempotent action — then read and summarize it. When the skill is **reached for mid-task**, it says *not* to generate (a fresh generation streams for a minute or two and would stall the user's real request) — just read an existing map, or note in one line that none exists. Fixes an agent freezing into a "what do you want to do?" menu when the skill was run in a repo with no map. Reinstall the updated guide with `graphlm --install-skill claude --skill-force`
 - Package author contact is now a role address (`graphlm@519lab.com`) instead of a personal one, and the Code of Conduct routes to `conduct@519lab.com`. (v0.1.0's PyPI metadata carried the old address; a published version's metadata can't be edited, so this takes effect from the next release.)
 
 ### Added

--- a/graphlm/skills.py
+++ b/graphlm/skills.py
@@ -40,9 +40,12 @@ class SkillInstallResult:
 def _skill_markdown_body() -> str:
     """The guide's Markdown body — shared by every harness.
 
-    Written to no-op gracefully in a repo that has no map yet (it tells the
-    agent to generate one), so a user-global install doesn't misfire in
-    unmapped repos.
+    Distinguishes two invocation modes, which want opposite defaults when no map
+    exists: an *explicit* invocation generates one (`graphlm .`) without asking;
+    a *self-reached* invocation mid-task does not (generating streams for a minute
+    or two and would stall the user's real task). This is what keeps a
+    user-global install from either freezing on explicit use or misfiring on
+    auto-use in an unmapped repo.
     """
     return """\
 ## Use graphlm's codebase map
@@ -50,28 +53,53 @@ def _skill_markdown_body() -> str:
 [graphlm](https://github.com/ggrace519/graphLM) generates a **map of a
 codebase** — modules, import/dependency edges, data flow, entry points, import
 cycles, and "where do I find X?" answers — as Markdown, JSON, and interactive
-HTML.
+HTML. It lives at `.graphlm/GRAPH.md` (machine-readable `.graphlm/GRAPH.json`;
+clickable `.graphlm/GRAPH.html`).
 
-**When you start working in a repository, look for a graphlm map before
-exploring the code by hand:**
+**First, know which situation you're in — the right action differs.**
 
-1. **Check for `.graphlm/GRAPH.md`** in the project root. If it exists, read it
-   first — it orients you far faster than opening files one at a time. The
-   machine-readable form is `.graphlm/GRAPH.json`; the clickable graph is
-   `.graphlm/GRAPH.html`.
-2. **Follow the map's refresh directive.** `GRAPH.md` opens with a provenance
-   stamp naming the git commit it was generated against. Compare it to the
-   repo's current `git rev-parse HEAD`; if they differ, the map may be stale —
-   regenerate it with `graphlm .` from the project root.
-3. **If there is no `.graphlm/GRAPH.md`,** and graphlm is installed and the
-   project is nontrivial, generate one: `graphlm .` (writes into `.graphlm/`).
-   If graphlm isn't installed or you can't reach its LLM endpoint, just skip
-   this — it's an optional aid, not a requirement.
-4. **What changed since last time?** `.graphlm/GRAPH_DIFF.md` lists the modules,
-   edges, and cycles added/removed since the previous run — a fast way to see
-   structural drift without re-reading the whole map.
+### A. You were invoked *explicitly* to work with the map
 
-Notes:
+(The user ran the graphlm command/skill directly, with no other task — they want
+the map.)
+
+- **If `.graphlm/GRAPH.md` exists:** read it, then briefly tell the user what the
+  codebase looks like (its main modules, entry points, any notable import
+  cycles). Check the refresh directive (below) and offer to regenerate if stale.
+- **If it does NOT exist:** **generate it — run `graphlm .` — without asking.**
+  This is the expected outcome of an explicit invocation, and it's a safe,
+  local, idempotent action (no network side effects beyond one call to the LLM
+  endpoint graphlm is already configured for; it only writes into `.graphlm/`).
+  Do **not** stall with a menu or ask permission for this specific command. Then
+  read the map you just generated and summarize it. Generation streams and can
+  take a minute or two on a large repo — that's normal; let it run.
+- Only stop to ask if graphlm is **not installed** or its **LLM endpoint isn't
+  configured/reachable** (`graphlm .` will say so) — then tell the user what's
+  missing instead of guessing.
+
+### B. You reached for this yourself while doing *another* task
+
+(The user asked for a feature/bug/exploration; you're orienting.)
+
+- **If `.graphlm/GRAPH.md` exists:** read it first — it orients you faster than
+  opening files one by one. Follow the refresh directive; a quick
+  `git rev-parse HEAD` mismatch means it may be stale.
+- **If it does NOT exist:** do **not** generate one mid-task — a fresh generation
+  can take minutes and would stall the work the user actually asked for. Just
+  note in one line that no map exists (and that `graphlm .` would create one),
+  then proceed with the real task normally. Suggest generating it only if the
+  user seems to be starting a longer effort in an unfamiliar codebase.
+
+### The refresh directive
+
+`.graphlm/GRAPH.md` opens with a provenance stamp naming the git commit it was
+generated against. Compare it to the repo's current `git rev-parse HEAD`; if they
+differ, the map may be stale — regenerate with `graphlm .` from the project root.
+`.graphlm/GRAPH_DIFF.md` lists what changed (modules, edges, cycles added/removed)
+since the previous run.
+
+### Notes
+
 - The map is **advisory** and best-effort. Trust the code over the map when they
   disagree; a stale map is possible (regenerate to be sure).
 - graphlm needs an OpenAI-compatible LLM endpoint (`GRAPHLM_BASE_URL` /

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -30,6 +30,21 @@ class TestInstallSkill:
         # Tells the agent to regenerate when missing/stale (graceful no-op).
         assert "graphlm ." in content
 
+    def test_body_distinguishes_explicit_vs_self_invocation(self, tmp_path):
+        # The skill must give opposite defaults for the two invocation modes:
+        # explicit invocation → generate the map without asking; self-reached
+        # mid-task → do NOT generate (it would stall the user's real task).
+        # This is the behavior that made Claude stall into a menu before.
+        content = install_skill("claude", home=tmp_path).path.read_text()
+        lower = content.lower()
+        # Explicit case: generate without asking.
+        assert "explicit" in lower
+        assert "without asking" in lower
+        # Self-reached case: do not generate mid-task.
+        assert "mid-task" in lower or "another task" in lower
+        # The reason the two differ (latency of a streamed generation) is stated.
+        assert "stall" in lower
+
     def test_codex_global_writes_guide_and_note(self, tmp_path):
         result = install_skill("codex", home=tmp_path)
         expected = tmp_path / ".codex" / "graphlm.md"


### PR DESCRIPTION
## Summary

The `--install-skill` guide gave one instruction for both invocation modes, which want **opposite** defaults when a repo has no map. Running the skill explicitly (`/graphlm`) in an unmapped repo made the agent stall into a "what do you want to do?" menu instead of just generating the map.

Reported from a real session in `python-tetris`: the agent oriented correctly, found no map, confirmed graphlm was installed — then froze and offered a 2-option menu rather than generating.

## The fix

The two modes now diverge in `_skill_markdown_body()`:

- **Explicit invocation** (user ran the skill/command directly, no other task): if no map exists, **generate one with `graphlm .` without asking** — it's local, idempotent, and non-destructive — then read and summarize it. Only stop if graphlm isn't installed or its endpoint is unreachable.
- **Self-reached mid-task** (user asked for something else, agent is orienting): **do not** generate — a fresh generation streams for a minute or two (per the pass-2 streaming design, ~200s on a large repo) and would stall the user's real request. Read an existing map, or note in one line that none exists, and proceed.

## Why these specific choices

- Fixed in the **source** (`_skill_markdown_body()`), not the installed copy — so it reaches every future install and `--skill-force` reinstall.
- **`description` frontmatter unchanged** — the failure was explicit invocation, which never consults the description; broadening it would make the skill auto-fire *more* in exactly the unmapped repos where auto-generating goes badly.
- The body is **shared with the Codex guide**, so the explicit-invocation wording is harness-neutral (`/graphlm` is a Claude concept; the guide says "invoked explicitly" instead).

## Verification
- `uv run pytest -q` → **393 passed** (added a test asserting both modes' guidance is present).
- `uv run mypy graphlm --ignore-missing-imports` clean.
- Rendered SKILL.md inspected; the decisive "generate without asking" / "do not generate mid-task" lines are present and unambiguous.

## Post-merge note
- Users reinstall the updated guide with `graphlm --install-skill claude --skill-force` (after the next release ships this body). No API/behavior change to graphlm itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DiZwx1UJrf7wu3suBzq6x