### PR TITLE
chore(release): 0.1.1 — skill-invocation fix + community-health docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-08-31
+
+Maintenance release: a fix to the `--install-skill` agent guide, plus the
+community-health docs and role-address contact change made after 0.1.0 shipped.
+
 ### Changed
 
 - `--install-skill` guide now distinguishes the two invocation modes so an agent doesn't stall or misfire. When it's invoked **explicitly** (the user ran the skill/command directly) and no map exists, the guide says to generate one with `graphlm .` **without asking** — a safe, local, idempotent action — then read and summarize it. When the skill is **reached for mid-task**, it says *not* to generate (a fresh generation streams for a minute or two and would stall the user's real request) — just read an existing map, or note in one line that none exists. Fixes an agent freezing into a "what do you want to do?" menu when the skill was run in a repo with no map. Reinstall the updated guide with `graphlm --install-skill claude --skill-force`
@@ -110,5 +115,6 @@ First public release. graphlm is installable from PyPI (`uv tool install graphlm
 - mypy type checking in CI
 - Removed stale generated artifacts (`graphs.md`, `graphs.json`, `graph.html`) left over from before the `GRAPH.*` output rename, and the committed `.coverage` database; the repo no longer ships tool output. Added `.coverage`, `coverage.xml`, and the `GRAPH.*` output files to `.gitignore` so generated artifacts stay out of version control
 
-[Unreleased]: https://github.com/ggrace519/graphLM/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/ggrace519/graphLM/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/ggrace519/graphLM/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ggrace519/graphLM/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphlm"
-version = "0.1.0"
+version = "0.1.1"
 description = "Generate codebase graphs (Markdown + JSON + interactive HTML) from any project directory using an OpenAI-compatible LLM"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ toml = [
 
 [[package]]
 name = "graphlm"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **0.1.1**, a maintenance release over 0.1.0. Bumps `version` to `0.1.1` and promotes the `[Unreleased]` changelog to `[0.1.1]`.

## What's in 0.1.1
- **fix(skills)** (#36) — the `--install-skill` agent guide now distinguishes explicit vs mid-task invocation: generate the map without asking on explicit use, don't stall the user's real task on auto-use.
- **docs** (#35) — community-health files (CONTRIBUTING, SECURITY with private vuln reporting, CODE_OF_CONDUCT, PR + issue templates).
- Package author + Code of Conduct now use **role addresses** (`graphlm@519lab.com` / `conduct@519lab.com`), not a personal email — effective from this release's PyPI metadata (0.1.0's can't be edited).

No change to graphlm's analysis pipeline.

## Verification
- `uv run pytest -q` → **393 passed**; `mypy` clean.
- `uv build` produces `graphlm-0.1.1` artifacts; metadata shows `Version: 0.1.1` and `Author-email: Greg Grace <graphlm@519lab.com>`.
- `graphlm --version` → `graphlm 0.1.1`; `uv lock --check` clean.

## Post-merge
- Tag `v0.1.1` → the release workflow publishes to PyPI (Trusted Publishing) + a GitHub Release. Same wiring proven on 0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DiZwx1UJrf7wu3suBzq6x