### PR TITLE
fix(skills): trigger at start of codebase work + warn on code egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+### Changed
+
+- `--install-skill` guide improvements, from testing it across Claude, Codex, and Grok:
+  - **Stronger trigger.** The skill `description` now tells the agent to reach for the map at the **start** of working in a codebase — before reading or searching through files — rather than only when explicitly asked. This is safe now that the guide handles an unmapped repo gracefully (it no longer risks a mid-task stall).
+  - **Data-egress heads-up.** The guide now notes that `graphlm .` **sends selected repository code to the configured LLM endpoint** (`GRAPHLM_BASE_URL`). It still generates without stalling for a local/trusted endpoint, but says to surface the destination and get a quick OK when the endpoint is a third-party API — so a private codebase isn't exported silently. (A Codex safety layer flagged exactly this.)
+  - Reinstall the updated guide with `graphlm --install-skill claude --skill-force`.
+
 ## [0.1.1] - 2026-08-31
 
 Maintenance release: a fix to the `--install-skill` agent guide, plus the

--- a/graphlm/skills.py
+++ b/graphlm/skills.py
@@ -67,12 +67,18 @@ the map.)
   codebase looks like (its main modules, entry points, any notable import
   cycles). Check the refresh directive (below) and offer to regenerate if stale.
 - **If it does NOT exist:** **generate it — run `graphlm .` — without asking.**
-  This is the expected outcome of an explicit invocation, and it's a safe,
-  local, idempotent action (no network side effects beyond one call to the LLM
-  endpoint graphlm is already configured for; it only writes into `.graphlm/`).
-  Do **not** stall with a menu or ask permission for this specific command. Then
-  read the map you just generated and summarize it. Generation streams and can
-  take a minute or two on a large repo — that's normal; let it run.
+  This is the expected outcome of an explicit invocation, and it's a local,
+  idempotent action that only writes into `.graphlm/`. Do **not** stall with a
+  menu. Then read the map you just generated and summarize it. Generation streams
+  and can take a minute or two on a large repo — that's normal; let it run.
+  - **One caveat worth a heads-up, not a stall:** generating a map **sends
+    selected repository file content** (typically tens of thousands of tokens)
+    to whatever endpoint graphlm is configured for (`GRAPHLM_BASE_URL`). If that
+    endpoint is **local or otherwise trusted**, just proceed. If it's a
+    **third-party API** — or you can't tell — say in one line where the code will
+    be sent and get a quick OK before running, since exporting a private codebase
+    is the user's call to make. Don't send code from a repo the user wouldn't
+    want shared with that endpoint.
 - Only stop to ask if graphlm is **not installed** or its **LLM endpoint isn't
   configured/reachable** (`graphlm .` will say so) — then tell the user what's
   missing instead of guessing.
@@ -102,6 +108,12 @@ since the previous run.
 
 - The map is **advisory** and best-effort. Trust the code over the map when they
   disagree; a stale map is possible (regenerate to be sure).
+- **Generating a map sends code off-box.** `graphlm .` transmits selected
+  repository file content to the configured LLM endpoint (`GRAPHLM_BASE_URL`).
+  That's fine for a local/trusted endpoint; for a third-party API, treat it as a
+  code-export the user should be aware of before you run it (see the caveat under
+  A above). graphlm redacts obvious secrets and skips sensitive files, but that's
+  defense-in-depth, not a guarantee.
 - graphlm needs an OpenAI-compatible LLM endpoint (`GRAPHLM_BASE_URL` /
   `GRAPHLM_API_KEY` / `GRAPHLM_MODEL`); `graphlm .` will tell you if it's not
   configured. `graphlm --help` lists every flag.
@@ -114,10 +126,14 @@ def _claude_skill_file(body: str) -> str:
         "---\n"
         "name: graphlm\n"
         "description: >-\n"
-        "  Read and refresh the graphlm codebase map (.graphlm/GRAPH.md) when working in "
-        "a repository. Use when orienting in an unfamiliar codebase, before exploring "
-        "files by hand, or when you need modules / import edges / entry points / import "
-        "cycles at a glance. Regenerate a missing or stale map with `graphlm .`.\n"
+        "  Read the graphlm codebase map (.graphlm/GRAPH.md) to get oriented in a "
+        "repository. Use this at the START of working in a codebase — before reading "
+        "or searching through files to understand the structure, and before answering "
+        "questions about how the project is laid out. It gives you modules, "
+        "import/dependency edges, entry points, and import cycles at a glance, so you "
+        "don't have to explore file-by-file. Reach for it whenever you're getting your "
+        "bearings in an unfamiliar or large repo. If the map is missing or stale, "
+        "regenerate it with `graphlm .`.\n"
         "---\n\n"
         "# graphlm codebase map\n\n"
     )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -30,6 +30,16 @@ class TestInstallSkill:
         # Tells the agent to regenerate when missing/stale (graceful no-op).
         assert "graphlm ." in content
 
+    def test_description_triggers_at_start_of_codebase_work(self, tmp_path):
+        # The description drives WHETHER the agent invokes the skill. It must
+        # trigger at the start of working in a repo, before reading files —
+        # otherwise the map is only used when explicitly asked for.
+        content = install_skill("claude", home=tmp_path).path.read_text()
+        # The description line lives in the frontmatter (before the body).
+        desc = content.split("---")[1].lower()
+        assert "start" in desc
+        assert "before reading" in desc or "before exploring" in desc or "before searching" in desc
+
     def test_body_distinguishes_explicit_vs_self_invocation(self, tmp_path):
         # The skill must give opposite defaults for the two invocation modes:
         # explicit invocation → generate the map without asking; self-reached
@@ -44,6 +54,17 @@ class TestInstallSkill:
         assert "mid-task" in lower or "another task" in lower
         # The reason the two differ (latency of a streamed generation) is stated.
         assert "stall" in lower
+
+    def test_body_warns_about_code_egress(self, tmp_path):
+        # Generating a map sends repo code to the configured endpoint; the guide
+        # must surface that so an agent with a third-party endpoint doesn't
+        # export a private codebase silently (a Codex safety layer caught this).
+        content = install_skill("claude", home=tmp_path).path.read_text()
+        lower = content.lower()
+        assert "GRAPHLM_BASE_URL" in content
+        assert "third-party" in lower
+        # Ties the egress to the configured endpoint / sending code.
+        assert "send" in lower or "transmit" in lower or "export" in lower
 
     def test_codex_global_writes_guide_and_note(self, tmp_path):
         result = install_skill("codex", home=tmp_path)


### PR DESCRIPTION
## Summary

Two refinements to the `--install-skill` agent guide, both from **testing it across Claude, Codex, and Grok** on a real repo (`python-tetris`). All three followed the 0.1.1 two-mode guide correctly; these tighten it further.

## 1. Stronger trigger (the behavior Greg asked for)

The skill `description` now directs the agent to consult the map at the **start** of working in a codebase — *"before reading or searching through files"* — instead of only when explicitly asked. The description is what drives *whether* the agent invokes the skill, so this is the right lever for "use the map before exploring the codebase."

This is safe now: the earlier reason to keep the description narrow (fear of auto-firing in an unmapped repo) no longer applies, because the body already handles the unmapped case gracefully (mode B: note it in one line, don't stall to generate).

## 2. Data-egress heads-up (surfaced by Codex)

When tested in Codex, its safety layer paused before `graphlm .`:

> *graphlm will send roughly 48,000 tokens of repository-derived file content to an unverified external destination; invoking the skill authorizes mapping in substance but does not specifically authorize this sensitive code export.*

That's a legitimate catch — and **Claude and Grok didn't pause, they just sent it.** The guide shouldn't rely on the harness to notice. It now states that `graphlm .` sends selected repo code to the configured endpoint (`GRAPHLM_BASE_URL`), still generates without stalling for a **local/trusted** endpoint, but says to surface the destination and get a quick OK for a **third-party API** — so a private codebase isn't exported silently.

## Verification
- `uv run pytest -q` → **395 passed** (added tests for the start-of-work trigger and the egress note); `mypy` clean.
- Rendered SKILL.md inspected; new description + both caveats present.

## Post-merge
- Ships in the next release; users reinstall with `graphlm --install-skill claude --skill-force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DiZwx1UJrf7wu3suBzq6x