### PR TITLE
chore(release): 0.1.2 — skill guide trigger + code-egress heads-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-08-31
+
+Maintenance release: `--install-skill` guide refinements from testing it across
+Claude, Codex, and Grok on a real repo.
+
 ### Changed
 
 - `--install-skill` guide improvements, from testing it across Claude, Codex, and Grok:
@@ -122,6 +127,7 @@ First public release. graphlm is installable from PyPI (`uv tool install graphlm
 - mypy type checking in CI
 - Removed stale generated artifacts (`graphs.md`, `graphs.json`, `graph.html`) left over from before the `GRAPH.*` output rename, and the committed `.coverage` database; the repo no longer ships tool output. Added `.coverage`, `coverage.xml`, and the `GRAPH.*` output files to `.gitignore` so generated artifacts stay out of version control
 
-[Unreleased]: https://github.com/ggrace519/graphLM/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/ggrace519/graphLM/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/ggrace519/graphLM/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ggrace519/graphLM/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ggrace519/graphLM/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphlm"
-version = "0.1.1"
+version = "0.1.2"
 description = "Generate codebase graphs (Markdown + JSON + interactive HTML) from any project directory using an OpenAI-compatible LLM"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ toml = [
 
 [[package]]
 name = "graphlm"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **0.1.2**, a maintenance release over 0.1.1. Bumps `version` to `0.1.2` and promotes `[Unreleased]` → `[0.1.2]`.

## What's in 0.1.2
- **fix(skills)** (#39) — `--install-skill` guide refinements from testing across Claude, Codex, and Grok:
  - The skill `description` now triggers at the **start** of codebase work (before reading/searching files), not just on explicit request.
  - The guide notes that `graphlm .` **sends repo code to the configured endpoint** — surface the destination for a third-party API rather than exporting a private codebase silently (Codex's safety layer flagged this).

No change to graphlm's analysis pipeline.

## Verification
- `uv run pytest -q` → **395 passed**; `mypy` clean.
- `uv build` → `graphlm-0.1.2`; metadata `Version: 0.1.2`, `Author-email: Greg Grace <graphlm@519lab.com>`.
- `graphlm --version` → `graphlm 0.1.2`; `uv lock --check` clean.

## Post-merge
- Tag `v0.1.2` → release workflow publishes to PyPI + GitHub Release (same wiring as 0.1.0/0.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DiZwx1UJrf7wu3suBzq6x