### PR TITLE
chore(release): add bump-my-version for release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- Release automation via [bump-my-version](https://github.com/callowayproject/bump-my-version) (`[tool.bumpversion]` in `pyproject.toml`). `uvx bump-my-version bump patch|minor|major` now bumps the version, promotes the `[Unreleased]` changelog section to a dated release header, updates the compare links, and makes a GPG-signed commit + signed tag — the mechanical release steps that were done by hand. `uv lock` and `git push --follow-tags` remain manual. See the "Releasing" section in `CONTRIBUTING.md`
+
 ## [0.1.2] - 2026-08-31
 
 Maintenance release: `--install-skill` guide refinements from testing it across

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,33 @@ and edge resolution against the scanned file set — plus a fixture project unde
 `tests/fixtures/` and tests. This is a great, well-scoped contribution; open an
 issue first so we can talk through the approach.
 
+## Releasing (maintainers)
+
+Releases publish to PyPI and a GitHub Release from a single `v*` tag (Trusted
+Publishing — see `.github/workflows/release.yml` and ADR-003). The mechanical
+steps are automated with [bump-my-version](https://github.com/callowayproject/bump-my-version)
+(config in `[tool.bumpversion]` in `pyproject.toml`):
+
+1. Make sure `## [Unreleased]` in `CHANGELOG.md` describes what's shipping and
+   `main` is clean.
+2. Bump — this updates `version` in `pyproject.toml`, promotes `[Unreleased]` to
+   a dated `## [X.Y.Z]` section, updates the compare links, and makes a
+   **GPG-signed** commit + signed tag `vX.Y.Z`:
+
+   ```bash
+   uvx bump-my-version bump patch   # or: minor / major
+   ```
+
+   Dry-run first to see the exact changes without touching anything:
+   `uvx bump-my-version bump patch --dry-run --verbose`.
+3. `uv lock` (the version change dirties the lockfile; bump-my-version doesn't
+   run this) and amend it into the release commit, or commit it separately.
+4. `git push --follow-tags`. The tag fires the release workflow.
+
+Publishing is irreversible (a PyPI version can't be reused); rehearse risky
+changes against TestPyPI first via the workflow's `workflow_dispatch` →
+`testpypi`.
+
 ## Reporting security issues
 
 **Do not** open a public issue for a security vulnerability. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,37 @@ norecursedirs = ["tests/fixtures"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["graphlm"]
+
+# Release automation: `uvx bump-my-version bump patch|minor|major`
+# Bumps project.version (auto — config lives here), promotes the CHANGELOG's
+# [Unreleased] section to a dated release header, updates the compare links,
+# then makes a signed commit + signed tag `vX.Y.Z`. Run `uv lock` afterward
+# (bump-my-version does not) and `git push --follow-tags` to publish.
+# NOTE: keep current_version in step with project.version above.
+[tool.bumpversion]
+current_version = "0.1.2"
+commit = true
+tag = true
+sign_tags = true
+tag_name = "v{new_version}"
+tag_message = "graphlm v{new_version}"
+commit_args = "--gpg-sign"
+message = "chore(release): {new_version}"
+allow_dirty = false
+
+# CHANGELOG: insert a dated release header below the permanent [Unreleased]
+# heading (we keep [Unreleased], we don't rename it).
+[[tool.bumpversion.files]]
+filename = "CHANGELOG.md"
+search = "## [Unreleased]"
+replace = """## [Unreleased]
+
+## [{new_version}] - {utcnow:%Y-%m-%d}"""
+
+# CHANGELOG: rewrite the Unreleased compare link to the new version AND add the
+# new version's own compare link, in one replacement (order-independent).
+[[tool.bumpversion.files]]
+filename = "CHANGELOG.md"
+search = "[Unreleased]: https://github.com/ggrace519/graphLM/compare/v{current_version}...HEAD"
+replace = """[Unreleased]: https://github.com/ggrace519/graphLM/compare/v{new_version}...HEAD
+[{new_version}]: https://github.com/ggrace519/graphLM/compare/v{current_version}...v{new_version}"""


### PR DESCRIPTION
## Summary

Adds [bump-my-version](https://github.com/callowayproject/bump-my-version) config (`[tool.bumpversion]` in `pyproject.toml`) to automate the mechanical release steps that were done by hand — the version bump, the CHANGELOG promotion, and the signed tag.

## Why (and why scoped this way)

The version lives in **one place** (`pyproject.toml`; `graphlm_version()` reads installed metadata), so the usual "keep N version strings in sync" motivation doesn't apply here. The step that actually had manual friction was the **CHANGELOG dance** — promoting `## [Unreleased]` to a dated section and fixing two compare links every release. This config automates exactly that, plus the signed commit + signed tag.

## What `uvx bump-my-version bump patch` now does

- Bumps `project.version` **and** `tool.bumpversion.current_version` `0.1.2 → 0.1.3` (single source stays consistent — `project.version` is auto-handled since the config lives in `pyproject.toml`).
- Inserts a dated `## [X.Y.Z] - <utc date>` header below the permanent `## [Unreleased]` (keeps `[Unreleased]`, doesn't rename it).
- Rewrites the `[Unreleased]` compare link and adds the new version's compare link (one order-independent replacement).
- Makes a **GPG-signed** commit `chore(release): X.Y.Z` + **signed** tag `vX.Y.Z`.

`uv lock` and `git push --follow-tags` remain manual (documented in the config comment and CONTRIBUTING.md's new "Releasing" section) — bump-my-version doesn't run them.

## Verification

Verified with `--dry-run --verbose` (a real 0.1.2 → 0.1.3 dry-run, no writes) — the planned changes are exactly correct: both version strings, the CHANGELOG header inserted under a now-empty `[Unreleased]` with the shipping content correctly under the new dated header, both compare links, and the signed commit + tag. Also: `uv build` works, **395 tests pass**, mypy clean.

Config syntax grounded in bump-my-version's own docs (`docs/howtos/multiple-replacements.md`, `docs/reference/formatting-context.md`).

## Not included

Left the version single-sourced — deliberately **no** `__version__` constant added (that would reintroduce the duplication the design avoids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DiZwx1UJrf7wu3suBzq6x