### PR TITLE
fix(cli): correct --dry-run "Files scanned" label to reflect pass-2 selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- `--dry-run` mislabeled its file count. The line read `Files scanned: N`, but `N` was the number of files **selected for pass-2 analysis** (capped at `--max-pass2-files`, default 80), not the number of files scanned (bounded by `--max-files`, default 200). On any project with more than 80 source files the two differ, so the label under-reported the scan and read as a smaller repo than was actually walked. The line now reads `Files selected for pass-2 analysis: N`.
+
 ### Infrastructure
 
 - Release automation via [bump-my-version](https://github.com/callowayproject/bump-my-version) (`[tool.bumpversion]` in `pyproject.toml`). `uvx bump-my-version bump patch|minor|major` now bumps the version, promotes the `[Unreleased]` changelog section to a dated release header, updates the compare links, and makes a GPG-signed commit + signed tag — the mechanical release steps that were done by hand. `uv lock` and `git push --follow-tags` remain manual. See the "Releasing" section in `CONTRIBUTING.md`

--- a/graphlm/cli.py
+++ b/graphlm/cli.py
@@ -294,7 +294,10 @@ def main(
 
     if dry_run:
         typer.echo("Dry run complete. No LLM call was made.", err=True)
-        typer.echo(f"Files scanned: {result.files_analyzed}", err=True)
+        typer.echo(
+            f"Files selected for pass-2 analysis: {result.files_analyzed}",
+            err=True,
+        )
         typer.echo(
             f"Pass 1 context: ~{result.pass1_context_tokens} tokens", err=True
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,7 +105,10 @@ class TestCLI:
         result = runner.invoke(app, [str(small_project), "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run complete" in result.stdout or "Dry run complete" in result.stderr
-        assert "Files scanned:" in result.stdout or "Files scanned:" in result.stderr
+        assert (
+            "Files selected for pass-2 analysis:" in result.stdout
+            or "Files selected for pass-2 analysis:" in result.stderr
+        )
 
     def test_dry_run_medium_project(self, medium_project):
         result = runner.invoke(app, [str(medium_project), "--dry-run"])


### PR DESCRIPTION
## Summary

`graphlm --dry-run` mislabeled its file count. The summary line read
`Files scanned: N`, but `N` is `len(pass2_files)` — the files **selected for
pass-2 analysis**, capped at `--max-pass2-files` (default 80) — not the number
of files scanned (bounded by `--max-files`, default 200). On any project with
more than 80 source files the two diverge, so the label under-reported the scan
and made a large repo read as a small one.

Found while measuring per-repo baselines for the multi-language work (#42): two
different repos both reporting exactly `80` was the tell — 80 is
`max_pass2_files`, not a coincidence.

## What changed

- `graphlm/cli.py` — the dry-run line now reads
  `Files selected for pass-2 analysis: N`. The underlying field
  (`GraphResult.files_analyzed = len(pass2_files)`) was already correct; only the
  label was wrong. Scan bounding (`max_files`) was never affected.
- `tests/test_cli.py` — updated the assertion in `test_dry_run_small_project`
  to match the new label.
- `CHANGELOG.md` — `[Unreleased] / Fixed` entry.

## Verification

- `uv run pytest -q` → **395 passed**.
- `uv run graphlm . --dry-run` now prints
  `Files selected for pass-2 analysis: 80` (was `Files scanned: 80`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DiZwx1UJrf7wu3suBzq6x
