### PR TITLE
docs(plans): multi-language AST support design + implementation plan (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to Semantic Versioning.
 
 ### Docs
 
-- Design docs for multi-language AST support (#42): `docs/plans/multi-language-support.md` (research + the two-tier core/pack recommendation) and `docs/plans/multi-language-implementation.md` (phased build plan). No code change yet — this is the approved design for adding deterministic import-edge extraction beyond Python (core 4: Python/JS/TS/Java; other languages as opt-in pip extras with bundled resolvers).
+- Design docs for multi-language AST support (#42): `docs/plans/multi-language-support.md` (research + recommendation) and `docs/plans/multi-language-implementation.md` (phased build plan). No code change yet — this is the approved design for adding deterministic import-edge extraction beyond Python. Model: **Python is the only core language** (the sole grammar in the base install); every other language is an **opt-in pip extra** (`graphlm[js]`, `graphlm[java]`, `graphlm[rust]`, `graphlm[all]`) with a bundled, graphlm-authored resolver — no third-party plugin API. Planned packs, in build order: JS/TS, Java, Rust.
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to Semantic Versioning.
 
 - `--dry-run` mislabeled its file count. The line read `Files scanned: N`, but `N` was the number of files **selected for pass-2 analysis** (capped at `--max-pass2-files`, default 80), not the number of files scanned (bounded by `--max-files`, default 200). On any project with more than 80 source files the two differ, so the label under-reported the scan and read as a smaller repo than was actually walked. The line now reads `Files selected for pass-2 analysis: N`.
 
+### Docs
+
+- Design docs for multi-language AST support (#42): `docs/plans/multi-language-support.md` (research + the two-tier core/pack recommendation) and `docs/plans/multi-language-implementation.md` (phased build plan). No code change yet — this is the approved design for adding deterministic import-edge extraction beyond Python (core 4: Python/JS/TS/Java; other languages as opt-in pip extras with bundled resolvers).
+
 ### Infrastructure
 
 - Release automation via [bump-my-version](https://github.com/callowayproject/bump-my-version) (`[tool.bumpversion]` in `pyproject.toml`). `uvx bump-my-version bump patch|minor|major` now bumps the version, promotes the `[Unreleased]` changelog section to a dated release header, updates the compare links, and makes a GPG-signed commit + signed tag — the mechanical release steps that were done by hand. `uv lock` and `git push --follow-tags` remain manual. See the "Releasing" section in `CONTRIBUTING.md`

--- a/docs/plans/multi-language-implementation.md
+++ b/docs/plans/multi-language-implementation.md
@@ -1,0 +1,371 @@
+# Implementation plan: Multi-language AST support
+
+**Status:** Ready to build. Written for a fresh agent-loop to implement cold.
+**Tracking issue:** [#42](https://github.com/ggrace519/graphLM/issues/42).
+**Design baseline:** `docs/plans/multi-language-support.md` (approved 2026-08-30).
+**Repo state at write time:** `main` @ `e5ebf92`.
+
+Owner decisions this plan implements:
+1. **Core 4** = Python ✅, JavaScript, TypeScript, Java — base install, always
+   resolved.
+2. **Pack tier** = pip extras with **bundled, in-tree** resolvers; no plugin
+   API, no third-party code execution. Missing grammar → zero edges, not a crash.
+
+Each phase below is an independent PR that keeps `uv run pytest -q` green and
+references #42. **Do not start a phase until the prior one is merged and green.**
+
+---
+
+## Compatibility contract (must hold across every phase)
+
+Real consumers of `graphlm.parser`, verified in-tree:
+
+- `graphlm/__init__.py:36` → `from graphlm.parser import build_dependency_graph`
+- `tests/test_parser.py:10` → `ParsedFile, build_dependency_graph,
+  detect_import_cycles, detect_language, parse_file`
+- `tests/test_parser.py:305` → `from graphlm.parser import _source_roots`
+
+Therefore **`graphlm.parser` must keep exporting**:
+`ParsedFile`, `build_dependency_graph`, `detect_import_cycles`,
+`detect_language`, `parse_file`, `_source_roots`.
+
+After Phase 0 these become re-exports from the `parsers/` package. Existing tests
+must pass **unmodified** through Phase 0 — that is the proof the refactor changed
+no behavior.
+
+`ImportEdge.kind` already documents `'import' | 'from' | 'register' | 'include'
+| 'uses'` (models.py:16-18), so the model needs no change to admit new kinds —
+but see Phase 2/3 on choosing kind values (they are part of the diff contract).
+
+---
+
+## Phase 0 — Refactor: `parser.py` → `parsers/` package (no behavior change)
+
+**Goal:** split the 645-line `parser.py` (over the 600 limit) into a package,
+moving Python's resolver **verbatim**. Zero behavior change. This de-risks
+everything after it.
+
+**Layout:**
+```
+graphlm/parsers/
+  __init__.py       # re-exports the public contract above
+  base.py           # registry-driven _TreeSitterBackend, ParsedFile,
+                    #   shared resolution helpers, _dedupe_edges,
+                    #   detect_import_cycles, the group-by-language dispatch
+  python.py         # everything Python-specific, moved verbatim:
+                    #   _PY_*_QUERY, _parse_python_*, _module_candidates,
+                    #   _source_roots, _resolve_module_name, _resolve_import,
+                    #   _placeholder_edge, _parse_file_python
+graphlm/parser.py   # thin shim: `from graphlm.parsers import *`  (+ explicit
+                    #   re-export of the contract names, incl. _source_roots)
+```
+
+**Registry (the one real change to structure, still behavior-neutral):**
+Replace `_get_language`'s `if language == PYTHON` ladder with a table:
+
+```python
+# base.py
+@dataclass(frozen=True)
+class _GrammarSpec:
+    pip_module: str      # e.g. "tree_sitter_python"
+    accessor: str        # e.g. "language" ; TS uses "language_typescript"
+
+_GRAMMARS: dict[str, _GrammarSpec] = {
+    "python": _GrammarSpec("tree_sitter_python", "language"),
+}
+
+def _get_language(self, language: str):
+    if language in self._language_cache:
+        return self._language_cache[language]
+    spec = _GRAMMARS.get(language)
+    if spec is None:
+        raise ValueError(f"Unsupported language: {language}")
+    try:
+        mod = importlib.import_module(spec.pip_module)
+    except ImportError:
+        raise _GrammarUnavailable(language)   # NOT ValueError — caller degrades
+    lang = self._ts.Language(getattr(mod, spec.accessor)())
+    self._language_cache[language] = lang
+    return lang
+```
+
+`_GrammarUnavailable` is caught by `parse_file` / `build_dependency_graph`, which
+skip that file and log **once per language** (dedupe the warning). In Phase 0
+only `python` is registered, so this path is exercised by a unit test that
+registers a fake missing language.
+
+**Invariant — `_GrammarUnavailable` must never escape `build_dependency_graph`
+(load-bearing).** `__init__.py:229-234` wraps the entire `build_dependency_graph`
+call in `except Exception → warn → deterministic_edges = None`, and `diff.py`
+decision 5 reads `None` as "AST was off" (sets the AST dimension `compared=False`).
+So if a single uninstalled *pack* grammar let the exception escape, it would not
+degrade that one language — it would **zero every language's edges** for the run
+*and* make the diff report the AST dimension as not-compared on a run where AST
+was on. That is exactly the silent collapse decisions 4/5 exist to prevent.
+Therefore:
+- Per-language grammar failure contributes **zero edges for that language** and
+  leaves other languages' edges intact.
+- With `ast=True`, `build_dependency_graph` **returns a list, never `None`** — a
+  missing grammar is not an error at this layer. (`None` for
+  `deterministic_edges` remains reserved for `ast=False`, per decision 5.)
+This invariant is tested in Phase 3 (mixed-language, grammar absent), not just the
+pure-single-language case — see there.
+
+**Acceptance:**
+- `uv run pytest -q` — all ~395 tests pass **unmodified**.
+- `uv run mypy graphlm --ignore-missing-imports` clean.
+- Deterministic-edge count on this repo is unchanged (**51**). **Do NOT** measure
+  this via `graphlm . --dry-run` — that line prints the LLM's `import_edges`
+  (empty in dry-run), not `deterministic_edges`. Measure it directly:
+  ```bash
+  uv run python -c "
+  from pathlib import Path
+  from graphlm.parser import build_dependency_graph
+  from graphlm.scanner import scan_project
+  s = scan_project(Path('.'), max_files=200)
+  print(len(build_dependency_graph(s.file_fragments, project_dir=Path('.'), max_files=200)))
+  "  # expect 51
+  ```
+- `git grep 'from graphlm.parser import'` still resolves.
+- New test: a registered-but-uninstalled language yields `[]` edges + one log
+  line, no exception (see the never-escapes invariant below).
+
+**Commit:** `refactor(parser): split into parsers/ package (Python verbatim)`
+
+---
+
+## The resolver interface (introduced in Phase 0, filled in later phases)
+
+Each language module implements a small, uniform surface so `base.py`'s dispatch
+is language-agnostic:
+
+```python
+# each parsers/<lang>.py provides:
+LANGUAGE: str                       # "javascript"
+EXTENSIONS: dict[str, str]          # {".js": "javascript", ...}  (feeds EXT_TO_LANGUAGE)
+GRAMMAR: _GrammarSpec               # registered into _GRAMMARS
+def extract_imports(tree, path) -> list[_RawImport]: ...
+def resolve(imp: _RawImport, from_path: str, known: set[str],
+            ctx: _RepoContext) -> list[tuple[str, str]]:  # [(to_path, kind), ...]
+    ...
+```
+
+- `_RawImport` is a language-neutral carrier (the specifier text + a per-language
+  payload). Python's existing `_ParsedImport` becomes Python's payload type.
+- `_RepoContext` is computed **once per run** in `build_dependency_graph` and
+  passed down: `known` file set, per-language source roots, and any manifest data
+  a resolver needs (Java: nothing extra; Go: `go.mod` module path). Keeps
+  per-file resolution pure and cheap.
+- **`resolve` must never raise.** Return `[]` on anything unresolvable. A missing
+  edge is always preferred to a false one (#19).
+
+`build_dependency_graph` becomes: group fragments by `detect_language`, build the
+`_RepoContext` per language, resolve, merge, dedupe. The `!= PYTHON` filter is
+gone; unregistered/unavailable languages simply contribute nothing.
+
+---
+
+## Phase 1 — JavaScript / TypeScript (one shared resolver)
+
+Fixes the live facade defect (`SUPPORTED_LANGUAGES` claims JS/TS,
+`parse_file` returns empty) **and** delivers real edges.
+
+**Grammars — and the tsx-selection mechanism (name it, don't hand-wave).**
+`detect_language` maps **both** `.ts` and `.tsx` to `"typescript"`
+(`tests/test_parser.py:34-35` asserts this and must keep passing). So a registry
+keyed by *language name* alone cannot pick `language_tsx()` vs
+`language_typescript()` — the name is identical. **Decision:** grammar selection
+takes the **file suffix**, not just the language name. Concretely, make the
+registry value able to choose by suffix:
+
+```python
+# base.py — grammar selection is (language, suffix) -> _GrammarSpec
+_GRAMMARS: dict[str, _GrammarSpec | Callable[[str], _GrammarSpec]] = {
+    "python":     _GrammarSpec("tree_sitter_python", "language"),
+    "javascript": _GrammarSpec("tree_sitter_javascript", "language"),  # .js/.jsx
+    "typescript": lambda suffix: _GrammarSpec(
+        "tree_sitter_typescript",
+        "language_tsx" if suffix == ".tsx" else "language_typescript",
+    ),
+}
+def _get_language(self, language: str, suffix: str = ""):
+    entry = _GRAMMARS.get(language)
+    spec = entry(suffix) if callable(entry) else entry
+    ...  # cache key is (language, spec.accessor), not language alone
+```
+
+The `parse_file` / `build_dependency_graph` dispatch already has the path, so it
+passes `path.suffix` down. `.jsx` uses the javascript grammar (it handles JSX).
+Keep `EXT_TO_LANGUAGE`'s public names (`javascript`/`typescript`); the tsx split
+lives entirely inside grammar selection. **Cache by `(language, accessor)`** so
+TS and TSX are cached separately.
+
+**Extraction:** `import ... from "spec"`, `export ... from "spec"`,
+`require("spec")` (call expr), and dynamic `import("spec")`. Capture the string
+literal specifier.
+
+**Resolution (relative specifiers only — v1 scope):**
+- Only specifiers starting `.` / `..` resolve; bare specifiers (`react`) → drop
+  (node_modules rule, == Python stdlib).
+- Probe order: `<spec>`, then `<spec>.{ts,tsx,js,jsx,mjs,cjs}`, then
+  `<spec>/index.{ts,tsx,js,jsx,mjs,cjs}`. First hit in `known` wins.
+- **Explicitly out of scope (drop, don't half-resolve):** `tsconfig.json`
+  `paths`/`baseUrl` aliases, package `exports` maps. When any bare/aliased
+  specifier is dropped, the resolver is *known-partial* → trip the "not
+  exhaustive" framing (see "Honesty" below).
+
+**kind values (diff-contract decision):** use `"import"` for import/export-from,
+`"require"` for `require()`, `"import"` for dynamic `import()`. Document in
+DECISIONS.md — `(from,to,kind)` is the diff identity key.
+
+**Fixture:** `tests/fixtures/ts_project/` with a relative-import chain, an
+`index.ts` barrel, a `.tsx` file, a bare import (must be dropped), and a 2-node
+cycle. Assert exact edge set + that the bare import produced no edge.
+
+**Acceptance:**
+- Deterministic edges on a real TS repo go from 0 to **>0**. Measure with the
+  direct `build_dependency_graph` call (as in Phase 0), **not** `--dry-run`
+  (which prints the empty LLM `import_edges`). Record the number in the PR —
+  baseline `emberfall-game` = 0.
+- `parse_file(Path("x.ts"))` no longer returns empty for a file with imports.
+- mypy clean; full suite green.
+
+**Commit:** `feat(parser): deterministic import edges for JavaScript/TypeScript (#42)`
+
+---
+
+## Phase 2 — Java (completes the core 4)
+
+Verified tractable: `import com.acme.User;` → `com/acme/User.java` — a
+FQN→file model, Python's analog, **no** directory-as-target problem.
+
+**Grammar:** `java` → `(tree_sitter_java, language)`. Add `.java` to
+`EXT_TO_LANGUAGE`/`_SOURCE_EXTS` if not already (it's in `_SOURCE_EXTS`).
+
+**Extraction:** `import_declaration` nodes → `scoped_identifier`. Distinguish:
+- normal: `import com.acme.User;`
+- wildcard: `import com.acme.*;` (has `asterisk` child)
+- static: `import static com.acme.Helpers.now;` (has `static` child)
+
+**Resolution:**
+- **Source roots** are the #19 problem in Java clothing: reuse the
+  `_source_roots` *pattern* with Java root names — accept a prefix ending in
+  `src/main/java`, `src/test/java`, or `src` that directly contains the package.
+  The file's own `package com.acme.service;` declaration is a **disambiguator**:
+  a file at `src/main/java/com/acme/service/Foo.java` declaring
+  `package com.acme.service` confirms the root — use it to reject false roots.
+- normal import → `<root>/com/acme/User.java` in `known`.
+- static import → strip the trailing member, resolve the class file.
+- wildcard → the package is a **directory**; resolve to each `.java` directly in
+  that dir that's in `known` (a bounded fan-out), OR drop if that's too noisy —
+  **decide and document.** Recommend: resolve to files in the immediate package
+  dir only (no recursion), kind `"import"`.
+  - **Diff-churn consequence (decide with this in view):** because the edge
+    identity key is `(from,to,kind)` (decision 3), resolving a wildcard to every
+    `.java` in the package means **adding one file to a package mutates the edge
+    set of every wildcard importer** — a structurally-correct change that reads
+    as spurious diff noise in `GRAPH_DIFF.md`. This is an argument for *dropping*
+    wildcards (and tripping the non-exhaustive framing) rather than fanning them
+    out. Make the call knowing this; don't discover it in the first noisy diff.
+
+**kind values:** `"import"` (normal), `"static"` (static import). Wildcard edges,
+if kept, use `"import"`. Document.
+
+**Fixture:** `tests/fixtures/java_project/src/main/java/com/acme/...` with a
+normal import, a static import, a wildcard, a cross-package edge, and a cycle.
+
+**Acceptance:** exact edge set on the fixture, incl. correct root-stripping;
+static/wildcard handled per decision; suite green; mypy clean. Add
+`tree-sitter-java` to base deps.
+
+**Commit:** `feat(parser): deterministic import edges for Java (#42)`
+
+---
+
+## Phase 3 — First pack (Go **or** Rust) — proves the extras mechanism
+
+Recommend **Go** first (higher demand; forces the directory-target decision the
+edge model must accommodate anyway).
+
+**Packaging:** add `[project.optional-dependencies]` with `go = [...]`,
+`all = ["graphlm[go,...]"]`. Grammar is **not** a base dep — this phase proves
+the `_GrammarUnavailable` → zero-edges degradation on a clean base install.
+
+**Go specifics:**
+- Read `go.mod`'s `module <path>` line (in `_RepoContext`) to strip the module
+  prefix from import paths.
+- Imports resolve to a **package = directory**, not a file. Decision needed and
+  **must be made in this PR:** either (a) synthesize a representative `to_path`
+  (e.g. the dir + `/`), or (b) resolve to each `.go` file in that dir in `known`.
+  Recommend (b) for consistency with Java wildcard handling.
+- Self-check: Go forbids compile-time import cycles → **any** Go cycle graphlm
+  reports is a resolver bug. Add a fixture that asserts a valid Go tree produces
+  **zero** cycles.
+
+**Acceptance:**
+- On a base install (no `[go]`), a Go repo yields 0 edges + one log line, no
+  crash.
+- **Mixed-language degradation (the invariant test, not the pure case).** A
+  **Python + Go** tree with the Go grammar **absent** must yield the *unchanged*
+  Python edge count (equal to the Python-only baseline) **and**
+  `deterministic_edges is not None`. The pure "Go-only → 0 edges" case cannot
+  distinguish the poison-the-whole-run bug from correct degradation; this one can.
+- With `graphlm[go]` installed, the Go fixture yields the expected edge set and
+  **zero** cycles (Go forbids compile-time import cycles — any cycle is a bug).
+- CI: the **default** `uv sync --group dev` job already runs *without* the extra
+  and covers the degradation path. The **new** job is the one *with*
+  `graphlm[go]` installed, covering the enabled path. (Don't add a redundant
+  no-extra job — that's the default.)
+
+**Commit:** `feat(parser): Go language pack via optional extra (#42)`
+
+Rust / C / others follow the same template on demand.
+
+---
+
+## Honesty when a resolver is known-partial
+
+Reuse the mechanism `context.py` already has: when the edge table is capped, its
+framing flips to "not exhaustive — infer the rest." A resolver that drops
+bare/aliased specifiers (JS without tsconfig, Go without full module resolution)
+is *known-partial*. Surface a per-language "partial" signal from
+`build_dependency_graph` so the pass-2 edge block uses the non-exhaustive framing
+for those languages, even when the table isn't size-capped. This keeps a partial
+list from being presented to the model as complete ground truth (the #19 rule at
+the prompt layer).
+
+---
+
+## Cross-cutting, do once (final phase or folded into Phase 1)
+
+- **`cycles.py` render note:** cycle *interpretation* is language-specific
+  (Go cycle = bug; Python = smell; JS/TS = often benign) though scoring isn't.
+  Add a one-line qualifier in the rendered cycle section keyed on the languages
+  involved.
+- **`CLAUDE.md`:** replace "Only Python is fully implemented; JS/TS are
+  recognized by extension but return empty `ParsedFile`" in **lock-step** with
+  the phase that makes it false. Document the core/pack tiers, the extras, and
+  the registry/degradation contract.
+- **`DECISIONS.md`:** ADR — two-tier core/pack, bundled resolvers (no plugin
+  API), registry + ImportError degradation, per-language `kind` values as diff
+  contract, under-resolve-honestly rule.
+- **`CHANGELOG.md`:** an `[Unreleased] / Added` entry per phase, stakeholder-led
+  ("graphlm now extracts verified import edges for TypeScript projects…").
+- **`README` / `--help`:** document `graphlm[all]`, the extras, and (optional) a
+  `--languages` diagnostic listing which grammars are importable.
+
+---
+
+## Risks & how this plan retires them
+
+- **False edges** (the #19 lesson): every resolver starts under-resolving,
+  `resolve` never raises, partial resolvers trip the non-exhaustive framing.
+  Per-language cyclic fixtures with **exact** expected sets are the guard.
+- **ABI breakage on grammar upgrade:** loading was verified against core 0.26 for
+  all candidates; pin windows conservatively; the degradation path means a
+  future incompatible grammar fails soft (zero edges), not hard.
+- **Refactor regressing Python (#19):** Phase 0 moves Python **verbatim** with
+  the existing suite unmodified as the proof; no language is added in the same PR.
+- **Diff churn from `kind`:** `kind` values are fixed per language and documented
+  as contract before the first non-Python edges ship, so a later change is a
+  conscious contract change, not drift.

--- a/docs/plans/multi-language-implementation.md
+++ b/docs/plans/multi-language-implementation.md
@@ -6,10 +6,17 @@
 **Repo state at write time:** `main` @ `e5ebf92`.
 
 Owner decisions this plan implements:
-1. **Core 4** = Python ✅, JavaScript, TypeScript, Java — base install, always
-   resolved.
-2. **Pack tier** = pip extras with **bundled, in-tree** resolvers; no plugin
-   API, no third-party code execution. Missing grammar → zero edges, not a crash.
+1. **Python is the only core language** — the sole grammar in the base install,
+   the only language with a resolver today. Every other language is an **opt-in
+   pip extra** (`graphlm[js]`, `graphlm[java]`, … `graphlm[all]`) with a
+   **bundled, graphlm-authored, in-tree** resolver — no plugin API, no
+   third-party code. A missing grammar → zero edges for that language, not a
+   crash.
+2. **No non-Python resolver exists yet.** JS/TS are a facade returning an empty
+   `ParsedFile`. Every phase below *builds* a resolver from scratch; none flips
+   on something already there. There is no privileged non-Python language —
+   JS/TS is simply the first pack (for the reason in Phase 1), Java and the rest
+   follow by demand.
 
 Each phase below is an independent PR that keeps `uv run pytest -q` green and
 references #42. **Do not start a phase until the prior one is merged and green.**
@@ -154,8 +161,8 @@ def resolve(imp: _RawImport, from_path: str, known: set[str],
   payload). Python's existing `_ParsedImport` becomes Python's payload type.
 - `_RepoContext` is computed **once per run** in `build_dependency_graph` and
   passed down: `known` file set, per-language source roots, and any manifest data
-  a resolver needs (Java: nothing extra; Go: `go.mod` module path). Keeps
-  per-file resolution pure and cheap.
+  a resolver needs (Java: source-root names; Rust: nothing beyond the mod tree).
+  Keeps per-file resolution pure and cheap.
 - **`resolve` must never raise.** Return `[]` on anything unresolvable. A missing
   edge is always preferred to a false one (#19).
 
@@ -165,10 +172,21 @@ gone; unregistered/unavailable languages simply contribute nothing.
 
 ---
 
-## Phase 1 — JavaScript / TypeScript (one shared resolver)
+## Phase 1 — JavaScript / TypeScript pack (the first pack; proves the extras mechanism)
 
-Fixes the live facade defect (`SUPPORTED_LANGUAGES` claims JS/TS,
-`parse_file` returns empty) **and** delivers real edges.
+The **first opt-in pack** (`graphlm[js]`) and the phase that proves the whole
+Python-core / opt-in-extra machinery end to end — including the
+grammar-absent degradation path on a base install (see the mixed-language
+degradation test, moved here from what used to be a later phase). Chosen as the
+first pack for a concrete reason unrelated to any tier: it removes a **live**
+facade defect (`SUPPORTED_LANGUAGES` claims JS/TS, `parse_file` returns empty
+today) **and** delivers real edges for the most repos.
+
+**Packaging:** add `[project.optional-dependencies]` with
+`js = ["tree-sitter-javascript…", "tree-sitter-typescript…"]` and start the
+`all = ["graphlm[js]"]` aggregate. The grammars are **not** base deps — only
+`tree-sitter-python` is. On a base install (no `[js]`), a JS/TS repo must yield
+zero edges + one log line, never a crash.
 
 **Grammars — and the tsx-selection mechanism (name it, don't hand-wave).**
 `detect_language` maps **both** `.ts` and `.tsx` to `"typescript"`
@@ -228,16 +246,32 @@ cycle. Assert exact edge set + that the bare import produced no edge.
   (which prints the empty LLM `import_edges`). Record the number in the PR —
   baseline `emberfall-game` = 0.
 - `parse_file(Path("x.ts"))` no longer returns empty for a file with imports.
+- **Grammar-absent degradation on a base install** (this is the first pack, so
+  the extras path is proven here): with `[js]` **not** installed, a JS/TS repo
+  yields 0 edges + one log line, no crash.
+- **Mixed-language degradation (the invariant test, not the pure case).** A
+  **Python + TS** tree with the `[js]` grammars **absent** must yield the
+  *unchanged* Python edge count (equal to the Python-only baseline) **and**
+  `deterministic_edges is not None`. The pure "TS-only → 0 edges" case cannot
+  distinguish the poison-the-whole-run bug (see the never-escapes invariant in
+  Phase 0) from correct degradation; this one can.
+- CI: the **default** `uv sync --group dev` job runs *without* the extra and
+  covers the degradation path. Add a **new** job *with* `graphlm[js]` installed
+  to cover the enabled path. (Don't add a redundant no-extra job — that's the
+  default.) Later packs reuse this two-job pattern.
 - mypy clean; full suite green.
 
-**Commit:** `feat(parser): deterministic import edges for JavaScript/TypeScript (#42)`
+**Commit:** `feat(parser): JavaScript/TypeScript language pack via optional extra (#42)`
 
 ---
 
-## Phase 2 — Java (completes the core 4)
+## Phase 2 — Java pack
 
 Verified tractable: `import com.acme.User;` → `com/acme/User.java` — a
 FQN→file model, Python's analog, **no** directory-as-target problem.
+
+**Packaging:** `java = ["tree-sitter-java…"]` extra (not a base dep); extend
+`all`. Same two-CI-job pattern as Phase 1.
 
 **Grammar:** `java` → `(tree_sitter_java, language)`. Add `.java` to
 `EXT_TO_LANGUAGE`/`_SOURCE_EXTS` if not already (it's in `_SOURCE_EXTS`).
@@ -275,51 +309,44 @@ if kept, use `"import"`. Document.
 normal import, a static import, a wildcard, a cross-package edge, and a cycle.
 
 **Acceptance:** exact edge set on the fixture, incl. correct root-stripping;
-static/wildcard handled per decision; suite green; mypy clean. Add
-`tree-sitter-java` to base deps.
+static/wildcard handled per decision; grammar-absent degradation holds (base
+install → 0 Java edges, no crash, Python edges intact); suite green; mypy clean.
 
-**Commit:** `feat(parser): deterministic import edges for Java (#42)`
+**Commit:** `feat(parser): Java language pack via optional extra (#42)`
 
 ---
 
-## Phase 3 — First pack (Go **or** Rust) — proves the extras mechanism
+## Phase 3 — Rust pack
 
-Recommend **Go** first (higher demand; forces the directory-target decision the
-edge model must accommodate anyway).
+The third pack. By this point the extras mechanism is already proven (Phase 1),
+so this is "another resolver, same template" — no new machinery.
 
-**Packaging:** add `[project.optional-dependencies]` with `go = [...]`,
-`all = ["graphlm[go,...]"]`. Grammar is **not** a base dep — this phase proves
-the `_GrammarUnavailable` → zero-edges degradation on a clean base install.
+**Packaging:** add `rust = ["tree-sitter-rust…"]` and extend `all` to include it.
+Grammar is **not** a base dep.
 
-**Go specifics:**
-- Read `go.mod`'s `module <path>` line (in `_RepoContext`) to strip the module
-  prefix from import paths.
-- Imports resolve to a **package = directory**, not a file. Decision needed and
-  **must be made in this PR:** either (a) synthesize a representative `to_path`
-  (e.g. the dir + `/`), or (b) resolve to each `.go` file in that dir in `known`.
-  Recommend (b) for consistency with Java wildcard handling.
-- Self-check: Go forbids compile-time import cycles → **any** Go cycle graphlm
-  reports is a resolver bug. Add a fixture that asserts a valid Go tree produces
-  **zero** cycles.
+**Rust specifics:**
+- Two-step resolution: `mod foo;` declarations map to `foo.rs` / `foo/mod.rs`
+  (relative to the declaring file's directory), building the **module tree**;
+  then `use crate::/super::/self::…` paths resolve **against that module tree**,
+  not the raw filesystem. This is more involved than JS relative paths — budget
+  for it.
+- `crate::` = crate root (`src/lib.rs` or `src/main.rs`); `super::` = parent
+  module; `self::` = current module. External crates (`use serde::…`) → **drop**
+  (same rule as Python third-party / JS node_modules).
+- Under-resolve honestly: if the mod-tree walk is incomplete, trip the
+  non-exhaustive framing rather than emitting guesses.
 
 **Acceptance:**
-- On a base install (no `[go]`), a Go repo yields 0 edges + one log line, no
-  crash.
-- **Mixed-language degradation (the invariant test, not the pure case).** A
-  **Python + Go** tree with the Go grammar **absent** must yield the *unchanged*
-  Python edge count (equal to the Python-only baseline) **and**
-  `deterministic_edges is not None`. The pure "Go-only → 0 edges" case cannot
-  distinguish the poison-the-whole-run bug from correct degradation; this one can.
-- With `graphlm[go]` installed, the Go fixture yields the expected edge set and
-  **zero** cycles (Go forbids compile-time import cycles — any cycle is a bug).
-- CI: the **default** `uv sync --group dev` job already runs *without* the extra
-  and covers the degradation path. The **new** job is the one *with*
-  `graphlm[go]` installed, covering the enabled path. (Don't add a redundant
-  no-extra job — that's the default.)
+- With `graphlm[rust]` installed, the Rust fixture yields the expected edge set;
+  external-crate `use`s produce no edge.
+- On a base install (no `[rust]`), a Rust repo yields 0 edges + one log line, no
+  crash (the degradation path — already covered generically by the Phase 1
+  invariant test, re-asserted here for Rust).
 
-**Commit:** `feat(parser): Go language pack via optional extra (#42)`
+**Commit:** `feat(parser): Rust language pack via optional extra (#42)`
 
-Rust / C / others follow the same template on demand.
+Further packs (Go, C, Ruby, C#, …) follow the same template **only on demand** —
+none is planned here.
 
 ---
 
@@ -327,8 +354,8 @@ Rust / C / others follow the same template on demand.
 
 Reuse the mechanism `context.py` already has: when the edge table is capped, its
 framing flips to "not exhaustive — infer the rest." A resolver that drops
-bare/aliased specifiers (JS without tsconfig, Go without full module resolution)
-is *known-partial*. Surface a per-language "partial" signal from
+bare/aliased specifiers (JS without tsconfig aliases, Rust with an incomplete
+mod-tree walk) is *known-partial*. Surface a per-language "partial" signal from
 `build_dependency_graph` so the pass-2 edge block uses the non-exhaustive framing
 for those languages, even when the table isn't size-capped. This keeps a partial
 list from being presented to the model as complete ground truth (the #19 rule at
@@ -339,16 +366,17 @@ the prompt layer).
 ## Cross-cutting, do once (final phase or folded into Phase 1)
 
 - **`cycles.py` render note:** cycle *interpretation* is language-specific
-  (Go cycle = bug; Python = smell; JS/TS = often benign) though scoring isn't.
-  Add a one-line qualifier in the rendered cycle section keyed on the languages
+  (Python cycle = smell; JS/TS = often benign) though scoring isn't. Add a
+  one-line qualifier in the rendered cycle section keyed on the languages
   involved.
 - **`CLAUDE.md`:** replace "Only Python is fully implemented; JS/TS are
   recognized by extension but return empty `ParsedFile`" in **lock-step** with
-  the phase that makes it false. Document the core/pack tiers, the extras, and
-  the registry/degradation contract.
-- **`DECISIONS.md`:** ADR — two-tier core/pack, bundled resolvers (no plugin
-  API), registry + ImportError degradation, per-language `kind` values as diff
-  contract, under-resolve-honestly rule.
+  the phase that makes it false. Document the Python-core / opt-in-pack model,
+  the extras, and the registry/degradation contract.
+- **`DECISIONS.md`:** ADR — Python-core / opt-in-pack model (every non-Python
+  language is a pip extra with a bundled resolver, no plugin API), registry +
+  ImportError degradation, per-language `kind` values as diff contract,
+  under-resolve-honestly rule.
 - **`CHANGELOG.md`:** an `[Unreleased] / Added` entry per phase, stakeholder-led
   ("graphlm now extracts verified import edges for TypeScript projects…").
 - **`README` / `--help`:** document `graphlm[all]`, the extras, and (optional) a

--- a/docs/plans/multi-language-support.md
+++ b/docs/plans/multi-language-support.md
@@ -1,0 +1,321 @@
+# Plan: Multi-language support (AST parsing beyond Python)
+
+**Status:** Research / recommendation. Not yet approved, not yet built.
+**Tracking issue:** [#42](https://github.com/ggrace519/graphLM/issues/42).
+**Implementation plan:** `docs/plans/multi-language-implementation.md`.
+**Repo state at write time:** `main` @ `e5ebf92`.
+**Empirical basis:** all version/ABI/baseline claims below were measured on
+2026-08-30 (Debian 13, Python 3.13, core `tree-sitter` 0.26.0) — not read off
+docs. Commands are shown so a fresh agent can reproduce them.
+
+**Owner decisions (2026-08-30 session):**
+1. **Core 4 = Python, JavaScript, TypeScript, Java** — deterministic ground
+   truth, always installed, always resolved.
+2. **Non-core languages ship as pip extras with *bundled* resolvers.** graphlm
+   writes and tests every resolver in-tree; the extra only gates the grammar
+   *wheel* install. **No third-party plugin API, no arbitrary-code execution.**
+
+---
+
+## The one-line reframe
+
+**This is not "make graphlm parse JS/TS/Java."** The scanner already ingests
+those files, ranks them into the `max_files` cap, and packs tens of thousands of
+tokens of them into the pass-2 prompt — where the LLM emits `import_edges` for
+them *with no deterministic ground truth to check against*. So the real work is:
+
+> **Add deterministic AST ground truth to languages the LLM already guesses at.**
+
+The parsing half is cheap (~20 lines of query per language). The expensive,
+per-language half is **import resolution** — mapping an import statement onto a
+file that exists in the scan. That is where all the risk lives.
+
+---
+
+## Two-tier architecture
+
+```
+CORE TIER (base install, always resolved)
+  graphlm/parsers/python.py      ✅ done — moved verbatim from parser.py
+  graphlm/parsers/javascript.py  ← JS + TS + TSX (one shared resolver)
+  graphlm/parsers/java.py        ← FQN → path, source roots
+
+PACK TIER (pip extra, bundled resolver, opt-in grammar wheel)
+  graphlm/parsers/go.py          shipped in-tree; `graphlm[go]` pulls the wheel
+  graphlm/parsers/rust.py        shipped in-tree; `graphlm[rust]` pulls the wheel
+  graphlm/parsers/c.py           shipped in-tree; `graphlm[c]` pulls the wheel
+  ...
+```
+
+The **only** difference between a core language and a pack language is whether its
+tree-sitter grammar wheel is a base dependency or gated behind an extra. The
+resolver code lives in-tree and is tested by graphlm's own suite either way. A
+pack whose grammar isn't installed **degrades to zero edges** for that language
+(one log line), never a crash — this is what makes the base install lean while
+keeping every language first-class-quality when enabled.
+
+This deliberately rejects a runtime plugin/entry-point API: no locked-forever
+public resolver contract, no running untrusted third-party resolver code. The
+cost is "only languages we wrote resolvers for" — accepted.
+
+---
+
+## Empirical baseline (measured, not asserted)
+
+`build_dependency_graph` today, run against real sibling repos:
+
+| Repo                      | Lang | Files scanned | `deterministic_edges` |
+|---------------------------|------|--------------:|----------------------:|
+| graphlm (this repo)       | Py   | 90            | **51**                |
+| emberfall-game            | TS   | 190           | **0**                 |
+| lodescout-search          | JS   | 49            | **0**                 |
+| claude-usage-mon          | Rust | 47            | **0**                 |
+
+Reproduce:
+```bash
+uv run python -c "
+from pathlib import Path
+from graphlm.scanner import scan_project
+from graphlm.parser import build_dependency_graph
+for name,p in [('py','.'),('ts','../emberfall-game'),('rs','../claude-usage-mon')]:
+    s = scan_project(Path(p), max_files=200)
+    e = build_dependency_graph(s.file_fragments, project_dir=Path(p), max_files=200)
+    print(name, len(s.file_fragments), len(e))
+"
+```
+
+Via the CLI (`--dry-run`, no LLM cost) the TS repo packs **~93k tokens** of
+source into pass 2 and still returns 0 AST edges. That is the gap this fills:
+those 190 TS files are already sent to the model; today its edge claims about
+them are unverifiable.
+
+---
+
+## Why the current code is Python-only (the seam)
+
+`graphlm/parser.py` (645 lines — see "Forced refactor") presents a
+multi-language *facade* over a Python-only *implementation*:
+
+- `EXT_TO_LANGUAGE` maps `.js/.ts/.jsx/.tsx`, and `SUPPORTED_LANGUAGES`
+  advertises JS/TS.
+- **But** `_TreeSitterBackend._get_language` hardcodes `if language == PYTHON:
+  … raise ValueError` — only Python has a grammar wired in.
+- `parse_file` returns an **empty `ParsedFile()`** for JS/TS — indistinguishable
+  from "parsed fine, no imports found."
+- `build_dependency_graph` short-circuits: `if detect_language(...) != PYTHON:
+  continue`.
+- Every resolver helper (`_module_candidates`, `_source_roots`,
+  `_resolve_module_name`, `_resolve_import`) encodes **Python's** import model.
+
+`scanner.py:176` `_SOURCE_EXTS` already includes
+`.rb .go .rs .java .cs .cpp .c .h .hpp` — that is why non-Python files rank into
+the scan. Language support at the *scanner* level already exists; the *parser*
+stops at Python.
+
+---
+
+## Feasibility: grammars load against core 0.26 (verified)
+
+graphlm pins `tree-sitter>=0.26,<0.27`. Candidate grammar wheels declare *older*
+core requirements in their `[core]` extra (`~=0.22`/`~=0.23`/`~=0.24`), which
+raised the real question: **do they load against core 0.26?** Tested in an
+isolated venv (`tree-sitter==0.26.0` + each grammar): every one imported, built a
+`Language`, and parsed a trivial buffer **without error**. The tree-sitter
+language ABI is forward-compatible here; the version markers are conservative.
+
+| Grammar wheel            | Version | `Language()` + parse vs core 0.26 | Tier |
+|--------------------------|---------|-----------------------------------|------|
+| tree-sitter-python       | 0.25.0  | OK (`module`)                     | core |
+| tree-sitter-javascript   | 0.25.0  | OK (`program`)                    | core |
+| tree-sitter-typescript   | 0.23.2  | OK — accessor note below          | core |
+| tree-sitter-java         | 0.23.5  | OK (`program`)                    | core |
+| tree-sitter-go           | 0.25.0  | OK (`source_file`)                | pack |
+| tree-sitter-rust         | 0.24.2  | OK (`source_file`)                | pack |
+| tree-sitter-c            | 0.24.2  | OK (`translation_unit`)           | pack |
+| tree-sitter-cpp          | 0.23.4  | OK (`translation_unit`)           | pack |
+| tree-sitter-ruby         | 0.23.1  | OK (`program`)                    | pack |
+| tree-sitter-c-sharp      | 0.23.5  | OK (`compilation_unit`)           | pack |
+
+**Accessor gotcha (confirmed):** `tree_sitter_typescript` has **no bare
+`language()`**. It exposes `language_typescript()` and `language_tsx()`. So the
+grammar registry keys on **`(module, accessor)` pairs**, and **TS + TSX are two
+grammar entries for one logical language.** Every other grammar uses `language()`.
+
+---
+
+## The core 4, spelled out
+
+Governing rule, carried forward from #19: **a false edge in the
+do-not-contradict table is worse than a missing one.** Each resolver starts
+deliberately *under*-resolving, and when it knows it is partial it trips the same
+honesty mechanism the edge-budget cap already uses in `context.py` (framing flips
+to "not exhaustive — infer the rest").
+
+### 1. Python — ✅ done
+Move `parser.py`'s resolver to `parsers/python.py` **verbatim** (do not
+re-litigate #19). Pure relocation, Python suite green before anything else moves.
+
+### 2 & 3. JavaScript / TypeScript — one shared resolver
+Specifiers are **path-relative** (`./foo`, `../bar/baz`), not dotted. Resolution:
+extension-probe order (`.ts .tsx .js .jsx .mjs .cjs`), then `<spec>/index.*`.
+Bare specifiers (`react`, `lodash`) → node_modules → **drop** (same rule as
+Python stdlib). `import`, `require()`, and dynamic `import()` all count as edges;
+decide the `kind` label (see models.py touch below). **Out of scope for v1:**
+`tsconfig.json` `paths`/`baseUrl` aliases and package `exports` maps — the rabbit
+hole. Relative specifiers alone cover most intra-repo edges. TS + TSX are two
+grammar registrations feeding this one resolver.
+
+### 4. Java — closer to Python than to Go (verified)
+Confirmed against the real grammar: `import com.acme.model.User;` parses to a
+`scoped_identifier` `com.acme.model.User`, which maps to path
+`com/acme/model/User.java` — a **fully-qualified-name → file** model, the direct
+analog of Python's dotted-module → file. **No** Go-style directory-as-target
+mismatch.
+- **Source roots** are the #19 problem again: files live under
+  `src/main/java/…`, `src/test/java/…`, or `src/…` (Maven/Gradle), and the FQN is
+  relative to that root. Reuse the `_source_roots` *pattern* with Java root names
+  (`src/main/java`, `src/test/java`, `src`).
+- **`package com.acme.service;`** gives the file's own FQN — a real source-root
+  *disambiguator* Python lacks (verify the file sits where its package says).
+- **Two edge shapes to handle:** `import com.acme.model.*;` (wildcard → a package
+  = a directory of `.java` files — a fan-out, or resolve to the dir) and
+  `import static com.acme.util.Helpers.now;` (member → strip trailing member,
+  resolve the class file). Handle both explicitly or drop them honestly.
+
+---
+
+## Pack tier (bundled resolvers, opt-in wheels)
+
+Same resolver-quality bar as core; the language just isn't in the base install.
+
+- **Go** — import path is the **full module path** (`github.com/x/y/pkg`); read
+  `go.mod`'s `module` line to strip the prefix. Imports resolve to a **directory
+  (package), not a file** — a structural mismatch with `ImportEdge.to_path`.
+  **Decide before coding:** synthesize a representative file per package, or widen
+  the edge target to a directory. Self-check: Go forbids import cycles at compile
+  time, so any Go cycle graphlm reports is a resolver bug.
+- **Rust** — two steps: `mod foo;` → `foo.rs`/`foo/mod.rs`, then
+  `use crate::/super::/self::` resolves against the **module tree**.
+- **C/C++** — quoted `#include "foo.h"` is the easy win; users want **`.h`↔`.c`
+  pairing**. Angle-bracket includes → drop.
+- **Ruby / C#** — grammars load; resolvers are each their own effort. On demand.
+
+Cycle *interpretation* is language-specific (scoring in `cycles.py` is not):
+Go cycle = resolver bug; Python cycle = real smell; JS/TS cycle = common/benign.
+Worth a render note.
+
+---
+
+## Recommended build order
+
+1. **Refactor first** (`parser.py` → `parsers/` package, Python moved verbatim,
+   suite green). No behavior change — de-risks everything after.
+2. **JS/TS** — fixes a live facade defect (`SUPPORTED_LANGUAGES` claims them,
+   `parse_file` returns empty) *and* delivers real edges. Highest coverage.
+3. **Java** — completes the core 4.
+4. **First pack (Go or Rust)** — proves the extras mechanism end to end,
+   including the ImportError-degradation path.
+5. Remaining packs on demand.
+
+---
+
+## Forced refactor (not stylistic)
+
+`graphlm/parser.py` is **645 lines** — already over the 600-line house limit
+before adding anything. Splitting into `graphlm/parsers/` is **required**:
+
+- `parsers/base.py` — registry-driven `_TreeSitterBackend`, `ParsedFile`,
+  `ImportEdge` plumbing, resolution helpers shared across languages.
+- `parsers/python.py` — Python resolver moved **verbatim**.
+- `parsers/javascript.py`, `parsers/java.py`, then pack modules.
+- `parser.py` stays as a thin re-export shim so existing imports
+  (`from graphlm.parser import build_dependency_graph`) keep working.
+
+### Registry, not `if` ladder
+`_get_language` becomes a table lookup keyed on
+`(pip_module, accessor_fn_name)` — TS/TSX as two entries — that **degrades on
+`ImportError`** rather than raising, so a pack language whose wheel isn't
+installed yields no edges (one log line) instead of crashing the run. This is the
+load-bearing mechanism for the whole two-tier design.
+
+---
+
+## Packaging: core deps + pack extras
+
+```toml
+[project]
+dependencies = [
+  # …existing…
+  "tree-sitter>=0.26,<0.27",
+  "tree-sitter-python>=0.25,<0.26",
+  "tree-sitter-javascript>=0.25,<0.26",   # core
+  "tree-sitter-typescript>=0.23,<0.24",   # core
+  "tree-sitter-java>=0.23,<0.24",         # core
+]
+
+[project.optional-dependencies]
+go   = ["tree-sitter-go>=0.25,<0.26"]
+rust = ["tree-sitter-rust>=0.24,<0.25"]
+c    = ["tree-sitter-c>=0.24,<0.25", "tree-sitter-cpp>=0.23,<0.24"]
+all  = ["graphlm[go,rust,c]"]
+```
+
+The 4 core grammars become base deps (4 ABI windows, all verified satisfiable
+against core 0.26). Pin windows are illustrative — set from current versions at
+implementation time; *loading* was verified, exact upper bounds are judgment.
+`graphlm --version` / a `--languages` flag could report which grammars are
+actually importable, so users see what's active.
+
+---
+
+## Touch list (for the eventual implementer)
+
+- **`parser.py` → `parsers/` package** — split above; registry with
+  ImportError degradation; extend `EXT_TO_LANGUAGE` / `SUPPORTED_LANGUAGES`;
+  `parse_file` dispatch; `build_dependency_graph`: replace the `!= PYTHON` filter
+  with group-by-language → per-language resolve → merge.
+- **`models.py` + `diff.py`** — `ImportEdge.kind` carries Python's
+  `"import"`/`"from"`. The diff's edge identity key is `(from,to,kind)` and
+  DECISIONS.md decision 3 makes those keys the **contract**. Decide what `kind`
+  holds per language (JS: `"import"`/`"require"`; Java: `"import"`/`"static"`/
+  `"wildcard"`?) before shipping — it changes what counts as the same edge.
+- **`cycles.py`** — mixed-language edge set is fine mechanically; add the
+  language-specific interpretation note to the render.
+- **`scanner.py`** — `_SOURCE_EXTS` already covers targets; confirm `_rank_file`
+  ranks new source above docs the same way (#19). Likely no change.
+- **`CLAUDE.md`** — the "Only Python is fully implemented; JS/TS are recognized
+  by extension but return empty `ParsedFile`" claim moves in lock-step.
+- **`DECISIONS.md`** — new ADR: two-tier core/pack model, bundled-resolver
+  (no plugin API), registry + ImportError degradation, under-resolve-honestly
+  rule. (ADR material *once approved*.)
+- **Tests / fixtures** — all four fixture trees are Python. Per-language
+  fixtures needed; per CLAUDE.md **extend a fixture, don't mock file I/O.** A
+  cyclic fixture per language is the cheapest correctness check. Add a test that
+  asserts graceful degradation when a pack grammar is *not* installed.
+
+---
+
+## Small in-scope defect found while researching
+
+`SUPPORTED_LANGUAGES` advertises `javascript`/`typescript`, but `parse_file`
+returns an empty `ParsedFile()` for them — a caller cannot distinguish "parsed,
+no imports" from "not implemented." No live-pipeline bug
+(`build_dependency_graph` filters by language first), but `parse_file` is public
+surface with no internal caller and currently misleads. The JS/TS work fixes it;
+if deferred, the honest interim is to drop JS/TS from
+`SUPPORTED_LANGUAGES`/`EXT_TO_LANGUAGE` until they're real.
+
+---
+
+## Out of scope for v1 (say no explicitly)
+
+- Runtime plugin / entry-point API for third-party resolvers (rejected by owner
+  decision — bundled resolvers only).
+- tsconfig `paths`/`baseUrl` aliases and package `exports` maps.
+- node_modules / GOPATH / cargo-registry / Maven-repo resolution (all → drop,
+  like stdlib).
+- Cross-language edges (Python → compiled Rust ext, FFI). Edges stay within one
+  language.
+- Non-import structure (JS/TS `export`, Rust `pub`, call graphs). The Python
+  parser extracts some of these but they aren't in the deterministic edge table;
+  adding them per-language is a separate effort.

--- a/docs/plans/multi-language-support.md
+++ b/docs/plans/multi-language-support.md
@@ -9,11 +9,21 @@
 docs. Commands are shown so a fresh agent can reproduce them.
 
 **Owner decisions (2026-08-30 session):**
-1. **Core 4 = Python, JavaScript, TypeScript, Java** — deterministic ground
-   truth, always installed, always resolved.
-2. **Non-core languages ship as pip extras with *bundled* resolvers.** graphlm
-   writes and tests every resolver in-tree; the extra only gates the grammar
-   *wheel* install. **No third-party plugin API, no arbitrary-code execution.**
+1. **Python is the only core language** — it is the one language with a
+   deterministic resolver today, and the only one in the base install. Every
+   other language is an **opt-in extra**. (Earlier in the session a "core 4"
+   was floated; on reflection the owner narrowed it to Python-only, since no
+   non-Python resolver exists yet — there is no basis for privileging any of
+   them as core.)
+2. **Every non-Python language ships as a pip extra with a *bundled,
+   graphlm-authored* resolver.** graphlm writes and tests every resolver
+   in-tree; the extra only gates the grammar *wheel* install. **No third-party
+   plugin API, no arbitrary-code execution** (a runtime extension API was
+   considered and rejected — locked-forever public contract, untrusted code).
+3. **None of these resolvers exist yet.** Only Python is real; JS/TS are a
+   facade that returns an empty `ParsedFile`. So "add a language" always means
+   "write and test a new in-tree resolver," never "flip on something already
+   built."
 
 ---
 
@@ -32,31 +42,40 @@ file that exists in the scan. That is where all the risk lives.
 
 ---
 
-## Two-tier architecture
+## Architecture: Python core + opt-in language packs
 
 ```
-CORE TIER (base install, always resolved)
+CORE (base install — the ONLY always-on language)
   graphlm/parsers/python.py      ✅ done — moved verbatim from parser.py
-  graphlm/parsers/javascript.py  ← JS + TS + TSX (one shared resolver)
-  graphlm/parsers/java.py        ← FQN → path, source roots
+                                    the only real resolver that exists today
 
-PACK TIER (pip extra, bundled resolver, opt-in grammar wheel)
-  graphlm/parsers/go.py          shipped in-tree; `graphlm[go]` pulls the wheel
-  graphlm/parsers/rust.py        shipped in-tree; `graphlm[rust]` pulls the wheel
-  graphlm/parsers/c.py           shipped in-tree; `graphlm[c]` pulls the wheel
-  ...
+PACKS (pip extra, bundled graphlm-authored resolver, opt-in grammar wheel)
+  graphlm/parsers/javascript.py  ← JS+TS+TSX; `graphlm[js]` pulls the wheels
+  graphlm/parsers/java.py        ← FQN→path; `graphlm[java]` pulls the wheel
+  graphlm/parsers/rust.py        ← mod tree; `graphlm[rust]` pulls the wheel
+  ...                              (none built yet; JS/TS is the first)
 ```
 
-The **only** difference between a core language and a pack language is whether its
-tree-sitter grammar wheel is a base dependency or gated behind an extra. The
-resolver code lives in-tree and is tested by graphlm's own suite either way. A
-pack whose grammar isn't installed **degrades to zero edges** for that language
-(one log line), never a crash — this is what makes the base install lean while
-keeping every language first-class-quality when enabled.
+Planned packs: **JS/TS, Java, Rust** (in build order). Others (Go, C, Ruby, C#)
+are possible later on demand but are **not planned** — nothing here commits to
+them.
+
+**One rule, not a tier list:** Python is core because it is the one language
+with a resolver and graphlm's own language. Everything else is a pack — JS/TS is
+not privileged over Go; it is simply the *first* pack on the build order (for a
+concrete, non-tiering reason: it removes a live facade bug — see build order).
+
+The **only** difference between core and a pack is whether the tree-sitter
+grammar wheel is a base dependency or gated behind an extra. Every pack
+resolver lives in-tree and is tested by graphlm's own suite (they are *not*
+third-party). A pack whose grammar isn't installed **degrades to zero edges**
+for that language (one log line), never a crash — that degradation path is now
+the *common* path (any repo whose languages the user didn't install extras for),
+so it is exercised constantly rather than being a rare edge case.
 
 This deliberately rejects a runtime plugin/entry-point API: no locked-forever
 public resolver contract, no running untrusted third-party resolver code. The
-cost is "only languages we wrote resolvers for" — accepted.
+cost is "only languages graphlm ships a resolver for" — accepted.
 
 ---
 
@@ -123,18 +142,18 @@ isolated venv (`tree-sitter==0.26.0` + each grammar): every one imported, built 
 `Language`, and parsed a trivial buffer **without error**. The tree-sitter
 language ABI is forward-compatible here; the version markers are conservative.
 
-| Grammar wheel            | Version | `Language()` + parse vs core 0.26 | Tier |
-|--------------------------|---------|-----------------------------------|------|
-| tree-sitter-python       | 0.25.0  | OK (`module`)                     | core |
-| tree-sitter-javascript   | 0.25.0  | OK (`program`)                    | core |
-| tree-sitter-typescript   | 0.23.2  | OK — accessor note below          | core |
-| tree-sitter-java         | 0.23.5  | OK (`program`)                    | core |
-| tree-sitter-go           | 0.25.0  | OK (`source_file`)                | pack |
-| tree-sitter-rust         | 0.24.2  | OK (`source_file`)                | pack |
-| tree-sitter-c            | 0.24.2  | OK (`translation_unit`)           | pack |
-| tree-sitter-cpp          | 0.23.4  | OK (`translation_unit`)           | pack |
-| tree-sitter-ruby         | 0.23.1  | OK (`program`)                    | pack |
-| tree-sitter-c-sharp      | 0.23.5  | OK (`compilation_unit`)           | pack |
+| Grammar wheel            | Version | `Language()` + parse vs core 0.26 | Install    |
+|--------------------------|---------|-----------------------------------|------------|
+| tree-sitter-python       | 0.25.0  | OK (`module`)                     | **base**   |
+| tree-sitter-javascript   | 0.25.0  | OK (`program`)                    | pack `[js]`|
+| tree-sitter-typescript   | 0.23.2  | OK — accessor note below          | pack `[js]`|
+| tree-sitter-java         | 0.23.5  | OK (`program`)                    | pack `[java]`|
+| tree-sitter-rust         | 0.24.2  | OK (`source_file`)                | pack `[rust]`|
+| tree-sitter-go           | 0.25.0  | OK (`source_file`)                | not planned |
+| tree-sitter-c            | 0.24.2  | OK (`translation_unit`)           | not planned |
+| tree-sitter-cpp          | 0.23.4  | OK (`translation_unit`)           | not planned |
+| tree-sitter-ruby         | 0.23.1  | OK (`program`)                    | not planned |
+| tree-sitter-c-sharp      | 0.23.5  | OK (`compilation_unit`)           | not planned |
 
 **Accessor gotcha (confirmed):** `tree_sitter_typescript` has **no bare
 `language()`**. It exposes `language_typescript()` and `language_tsx()`. So the
@@ -143,7 +162,7 @@ grammar entries for one logical language.** Every other grammar uses `language()
 
 ---
 
-## The core 4, spelled out
+## Per-language resolution notes
 
 Governing rule, carried forward from #19: **a false edge in the
 do-not-contradict table is worse than a missing one.** Each resolver starts
@@ -151,22 +170,23 @@ deliberately *under*-resolving, and when it knows it is partial it trips the sam
 honesty mechanism the edge-budget cap already uses in `context.py` (framing flips
 to "not exhaustive — infer the rest").
 
-### 1. Python — ✅ done
-Move `parser.py`'s resolver to `parsers/python.py` **verbatim** (do not
-re-litigate #19). Pure relocation, Python suite green before anything else moves.
+**Python — ✅ the only built resolver.** Move `parser.py`'s resolver to
+`parsers/python.py` **verbatim** (do not re-litigate #19). Pure relocation,
+Python suite green before anything else moves. Everything below is a pack that
+does not exist yet.
 
-### 2 & 3. JavaScript / TypeScript — one shared resolver
-Specifiers are **path-relative** (`./foo`, `../bar/baz`), not dotted. Resolution:
-extension-probe order (`.ts .tsx .js .jsx .mjs .cjs`), then `<spec>/index.*`.
-Bare specifiers (`react`, `lodash`) → node_modules → **drop** (same rule as
-Python stdlib). `import`, `require()`, and dynamic `import()` all count as edges;
-decide the `kind` label (see models.py touch below). **Out of scope for v1:**
+**JavaScript / TypeScript (pack `[js]`)** — one shared resolver. Specifiers are
+**path-relative** (`./foo`, `../bar/baz`), not dotted. Resolution: extension-probe
+order (`.ts .tsx .js .jsx .mjs .cjs`), then `<spec>/index.*`. Bare specifiers
+(`react`, `lodash`) → node_modules → **drop** (same rule as Python stdlib).
+`import`, `require()`, and dynamic `import()` all count as edges; decide the
+`kind` label (see models.py touch below). **Out of scope for v1:**
 `tsconfig.json` `paths`/`baseUrl` aliases and package `exports` maps — the rabbit
 hole. Relative specifiers alone cover most intra-repo edges. TS + TSX are two
 grammar registrations feeding this one resolver.
 
-### 4. Java — closer to Python than to Go (verified)
-Confirmed against the real grammar: `import com.acme.model.User;` parses to a
+**Java (pack `[java]`)** — closer to Python than to Go (verified). Confirmed
+against the real grammar: `import com.acme.model.User;` parses to a
 `scoped_identifier` `com.acme.model.User`, which maps to path
 `com/acme/model/User.java` — a **fully-qualified-name → file** model, the direct
 analog of Python's dotted-module → file. **No** Go-style directory-as-target
@@ -182,27 +202,19 @@ mismatch.
   `import static com.acme.util.Helpers.now;` (member → strip trailing member,
   resolve the class file). Handle both explicitly or drop them honestly.
 
----
+**Rust (pack `[rust]`)** — the third planned pack. Two steps: `mod foo;` →
+`foo.rs`/`foo/mod.rs` (builds the module tree), then `use crate::/super::/self::`
+resolves against that **module tree**, not the raw filesystem. External crates
+(`use serde::…`) → drop. More involved than JS relative paths.
 
-## Pack tier (bundled resolvers, opt-in wheels)
-
-Same resolver-quality bar as core; the language just isn't in the base install.
-
-- **Go** — import path is the **full module path** (`github.com/x/y/pkg`); read
-  `go.mod`'s `module` line to strip the prefix. Imports resolve to a **directory
-  (package), not a file** — a structural mismatch with `ImportEdge.to_path`.
-  **Decide before coding:** synthesize a representative file per package, or widen
-  the edge target to a directory. Self-check: Go forbids import cycles at compile
-  time, so any Go cycle graphlm reports is a resolver bug.
-- **Rust** — two steps: `mod foo;` → `foo.rs`/`foo/mod.rs`, then
-  `use crate::/super::/self::` resolves against the **module tree**.
-- **C/C++** — quoted `#include "foo.h"` is the easy win; users want **`.h`↔`.c`
-  pairing**. Angle-bracket includes → drop.
-- **Ruby / C#** — grammars load; resolvers are each their own effort. On demand.
+**Not planned (possible later, on demand only):** Go (import path = full module
+path; resolves to a package = *directory*, a structural mismatch with
+`ImportEdge.to_path` that would need a decision first), C/C++ (`.h`↔`.c` pairing),
+Ruby, C#. Their grammars load fine against core 0.26 (see the table) — but no
+resolver is committed for them here.
 
 Cycle *interpretation* is language-specific (scoring in `cycles.py` is not):
-Go cycle = resolver bug; Python cycle = real smell; JS/TS cycle = common/benign.
-Worth a render note.
+Python cycle = real smell; JS/TS cycle = common/benign. Worth a render note.
 
 ---
 
@@ -210,12 +222,15 @@ Worth a render note.
 
 1. **Refactor first** (`parser.py` → `parsers/` package, Python moved verbatim,
    suite green). No behavior change — de-risks everything after.
-2. **JS/TS** — fixes a live facade defect (`SUPPORTED_LANGUAGES` claims them,
-   `parse_file` returns empty) *and* delivers real edges. Highest coverage.
-3. **Java** — completes the core 4.
-4. **First pack (Go or Rust)** — proves the extras mechanism end to end,
-   including the ImportError-degradation path.
-5. Remaining packs on demand.
+2. **JS/TS pack** — the first pack. Chosen first for a concrete reason unrelated
+   to tiering: it removes a *live* facade defect (`SUPPORTED_LANGUAGES` claims
+   JS/TS, `parse_file` returns empty today) *and* delivers real edges for the
+   most repos. This is also the PR that proves the whole opt-in-extra mechanism
+   end to end, including the ImportError-degradation path on a base install.
+3. **Java pack**, then **Rust pack**. These are the planned packs. None is
+   privileged over the others; each is the same shape of work (a new in-tree
+   resolver + its extra + fixtures). Further languages (Go, C, …) only on demand
+   — nothing here commits to them.
 
 ---
 
@@ -236,35 +251,36 @@ before adding anything. Splitting into `graphlm/parsers/` is **required**:
 `(pip_module, accessor_fn_name)` — TS/TSX as two entries — that **degrades on
 `ImportError`** rather than raising, so a pack language whose wheel isn't
 installed yields no edges (one log line) instead of crashing the run. This is the
-load-bearing mechanism for the whole two-tier design.
+load-bearing mechanism for the whole Python-core / opt-in-pack design.
 
 ---
 
-## Packaging: core deps + pack extras
+## Packaging: Python in the base, every other language an extra
 
 ```toml
 [project]
 dependencies = [
   # …existing…
   "tree-sitter>=0.26,<0.27",
-  "tree-sitter-python>=0.25,<0.26",
-  "tree-sitter-javascript>=0.25,<0.26",   # core
-  "tree-sitter-typescript>=0.23,<0.24",   # core
-  "tree-sitter-java>=0.23,<0.24",         # core
+  "tree-sitter-python>=0.25,<0.26",       # the ONLY grammar in the base install
 ]
 
 [project.optional-dependencies]
-go   = ["tree-sitter-go>=0.25,<0.26"]
+# Planned packs (in build order):
+js   = ["tree-sitter-javascript>=0.25,<0.26", "tree-sitter-typescript>=0.23,<0.24"]
+java = ["tree-sitter-java>=0.23,<0.24"]
 rust = ["tree-sitter-rust>=0.24,<0.25"]
-c    = ["tree-sitter-c>=0.24,<0.25", "tree-sitter-cpp>=0.23,<0.24"]
-all  = ["graphlm[go,rust,c]"]
+all  = ["graphlm[js,java,rust]"]
+# (Go / C / Ruby / C# extras would be added here only if those packs are ever built.)
 ```
 
-The 4 core grammars become base deps (4 ABI windows, all verified satisfiable
-against core 0.26). Pin windows are illustrative — set from current versions at
-implementation time; *loading* was verified, exact upper bounds are judgment.
-`graphlm --version` / a `--languages` flag could report which grammars are
-actually importable, so users see what's active.
+Only `tree-sitter-python` is a base dependency — the base install stays as lean
+as it is today. Every other grammar is behind an extra, so a user opts into
+exactly the languages they need (`graphlm[js]`, or `graphlm[all]`). Pin windows
+are illustrative — set from current versions at implementation time; grammar
+*loading* against core 0.26 was verified for all of these, exact upper bounds
+are judgment. `graphlm --version` / a `--languages` flag could report which
+grammars are actually importable, so users see what's active in their install.
 
 ---
 
@@ -285,9 +301,10 @@ actually importable, so users see what's active.
   ranks new source above docs the same way (#19). Likely no change.
 - **`CLAUDE.md`** — the "Only Python is fully implemented; JS/TS are recognized
   by extension but return empty `ParsedFile`" claim moves in lock-step.
-- **`DECISIONS.md`** — new ADR: two-tier core/pack model, bundled-resolver
-  (no plugin API), registry + ImportError degradation, under-resolve-honestly
-  rule. (ADR material *once approved*.)
+- **`DECISIONS.md`** — new ADR: Python-core / opt-in-pack model (every non-Python
+  language is a pip extra with a bundled resolver, no plugin API), registry +
+  ImportError degradation, under-resolve-honestly rule. (ADR material *once
+  approved*.)
 - **Tests / fixtures** — all four fixture trees are Python. Per-language
   fixtures needed; per CLAUDE.md **extend a fixture, don't mock file I/O.** A
   cyclic fixture per language is the cheapest correctness check. Add a test that


### PR DESCRIPTION
## Summary

Design docs for extending graphlm's deterministic AST import-edge extraction beyond Python. **No code change** — the approved design and phased plan for the multi-language epic (#42), for a fresh implementer to build cold.

## The core reframe

This is not "make graphlm parse JS/TS/Java." The scanner **already** ingests those files and packs tens of thousands of tokens of them into the pass-2 prompt — where the LLM emits `import_edges` for them with **zero deterministic ground truth to check against** (measured: a TS repo packs ~93k tokens, 0 deterministic edges; Python = 51). So the work is *adding deterministic ground truth to languages the LLM already guesses at*. The expensive half is per-language import **resolution**, not parsing.

## Decisions captured (owner, 2026-08-30)

- **Python is the only core language** — the sole grammar in the base install, the only language with a resolver today.
- **Every other language is an opt-in pip extra** (`graphlm[js]`, `graphlm[java]`, `graphlm[rust]`, `graphlm[all]`) with a **bundled, graphlm-authored, in-tree** resolver. **No third-party plugin API, no arbitrary-code execution.** A missing grammar degrades that one language to zero edges (one log line), never a crash — and that degradation is now the *common* path, so it's exercised constantly.
- **No non-Python resolver exists yet.** JS/TS are a facade returning empty. Every phase *builds* a resolver from scratch.

## What's planned

Packs, in build order: **JS/TS then Java then Rust.** Go / C / Ruby / C# grammars were verified to load against core tree-sitter 0.26, but **no resolver is committed** for them — later, on demand only.

## What changed

- `docs/plans/multi-language-support.md` — research + the Python-core / opt-in-pack recommendation, with grammar/ABI feasibility **verified against core tree-sitter 0.26** (all candidate grammars load; TS needs `(module, accessor)` pairs — `language_typescript()`/`language_tsx()`).
- `docs/plans/multi-language-implementation.md` — phased build plan. Phase 0 splits the 645-line `parser.py` (over the 600-line house limit) into a `parsers/` package with Python moved **verbatim** (don't re-litigate #19); Phase 1 JS/TS pack (first pack; proves the opt-in-extra + grammar-absent degradation mechanism), Phase 2 Java pack, Phase 3 Rust pack. Includes the resolver interface and the **never-escapes invariant** (a missing pack grammar must not poison the whole run).
- `CHANGELOG.md` — `[Unreleased] / Docs` entry.

## Verification

- Docs-only; `uv run pytest -q` → **395 passed** (unchanged).
- Feasibility claims were measured, not asserted: grammar loading tested in an isolated venv against core 0.26; per-repo edge baselines from direct `build_dependency_graph` calls (reproduce commands are in the docs).

## Post-merge note

Implementation follows in per-phase PRs, each referencing #42. This PR is the design gate; nothing ships to users yet.

Tracked in #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DiZwx1UJrf7wu3suBzq6x
