### PR TITLE
ci: add explicit read-only permissions to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Neither job needs to write anything (no releases, no PR comments, no checks
+# API calls) — read-only is the least privilege the checkout + test/typecheck
+# steps require. Addresses CodeQL actions/missing-workflow-permissions (#1, #2).
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- `ci.yml` now sets an explicit read-only `permissions: contents: read` at the workflow level. Neither the test nor typecheck job writes anything (no releases, no PR comments, no checks API calls), so this is least-privilege, not a behavior change; addresses CodeQL's `actions/missing-workflow-permissions` finding.
+
 ## [0.2.0] - 2026-09-03
 
 This release is the output of an innovation pass over the codebase (`INNOVATIONS.md`): the map becomes queryable by agents over MCP, every run stamps its real token usage and an LLM-vs-parser faithfulness score, the map gets a native Mermaid picture, and oversized files are sent as signature skeletons instead of being cut off.


### PR DESCRIPTION
## Summary
- CodeQL flagged `ci.yml`'s `test` and `typecheck` jobs for not declaring workflow permissions (alerts #1, #2), which leaves them on the repo's default `GITHUB_TOKEN` scope.
- Neither job needs write access anywhere (no releases, no PR comments, no checks API calls), so this adds a top-level `permissions: contents: read`.

## What changed and why
- `.github/workflows/ci.yml`: explicit read-only permissions block. `release.yml` already scopes permissions per-job; this brings `ci.yml` in line as least-privilege, not a behavior change.
- `CHANGELOG.md`: `[Unreleased] / Infrastructure` entry.

## Verification
- `uv run pytest -q` → 640 passed
- `uv run mypy graphlm --ignore-missing-imports` → clean
- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- This PR's own CI run is the live proof the reduced permissions are sufficient.

## Also reviewed (no code change)
Two other open CodeQL alerts are false positives on inspection, will dismiss with a note in the alert:
- **#4** `py/weak-sensitive-data-hashing` in `tests/fixtures/large_project/app/services/auth.py` — this is a synthetic sample tree used only to test the scanner/parser (`norecursedirs = ["tests/fixtures"]` in `pyproject.toml`, and the wheel only packages the `graphlm` package). Fake code with fake data; graphlm never ships or executes it.
- **#5** `py/incomplete-url-substring-sanitization` in `tests/test_html_render.py` — `"d3js.org" in html` is a test assertion that the D3 script tag rendered, not a security boundary check on an untrusted URL/host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhMa9VQQPB5m1Z9tP3eP4M