### PR TITLE
fix(ci): use supported node 24 action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
+          cache-dependency-glob: "**/uv.lock"
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -53,12 +55,14 @@ jobs:
   test-packs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
+          cache-dependency-glob: "**/uv.lock"
 
       - name: Set up Python
         run: uv python install 3.12
@@ -72,12 +76,14 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
+          cache-dependency-glob: "**/uv.lock"
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,14 @@ jobs:
     name: Build & smoke-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
+          prune-cache: true
+          cache-dependency-glob: "**/uv.lock"
 
       - name: Set up Python
         run: uv python install 3.12
@@ -75,7 +77,7 @@ jobs:
             print('ok:', p)"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -88,16 +90,16 @@ jobs:
     permissions:
       contents: write # create the release + upload assets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true
@@ -121,7 +123,7 @@ jobs:
       id-token: write # Trusted Publishing (OIDC) — no API token secret
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -141,7 +143,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Semantic Versioning.
 
 ## [Unreleased]
 
+### Infrastructure
+
+- **CI and release workflows now use current Node.js 24-based action majors.** GitHub was forcibly running the older checkout, artifact, and uv setup actions under a compatibility runtime and warning that their Node.js 20 runtime was deprecated (#80).
+
 ## [0.4.2] - 2026-09-05
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Upgrade checkout and artifact actions to their current Node.js 24 majors.
- Pin setup-uv v9.0.0 to its verified immutable commit.
- Preserve setup-uv v4 cache pruning and invalidation behavior explicitly.
- Upgrade action-gh-release to its supported Node.js 24 v3 release.

Closes #80

## Verification

- Official action refs exist and their action metadata declares `node24`.
- The pinned setup-uv commit has a valid GitHub-verified signature.
- `.venv/bin/pytest -q` — 792 passed, 8 skipped.
- `uv run mypy graphlm --ignore-missing-imports` — clean across 31 source files.
- `git diff --check` — clean.
- Independent review — approved with no remaining findings after cache/release compatibility fixes.

## Post-merge

No deployment or package release is required. Confirm the next CI and release runs contain no Node.js 20 deprecation annotations.

🤖 Generated with [Codex](https://Codex.com/Codex)