### PR TITLE
fix(ci): eliminate remaining workflow warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           enable-cache: true
           prune-cache: true
           cache-dependency-glob: "**/uv.lock"
+          cache-suffix: "test-py${{ matrix.python-version }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -42,7 +43,7 @@ jobs:
         run: uv run pytest --cov=graphlm --cov-report=xml --cov-report=term-missing -v
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: matrix.python-version == '3.13'
         with:
           files: ./coverage.xml
@@ -63,6 +64,7 @@ jobs:
           enable-cache: true
           prune-cache: true
           cache-dependency-glob: "**/uv.lock"
+          cache-suffix: "test-packs"
 
       - name: Set up Python
         run: uv python install 3.12
@@ -84,6 +86,7 @@ jobs:
           enable-cache: true
           prune-cache: true
           cache-dependency-glob: "**/uv.lock"
+          cache-suffix: "typecheck"
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           enable-cache: true
           prune-cache: true
           cache-dependency-glob: "**/uv.lock"
+          cache-suffix: "release"
 
       - name: Set up Python
         run: uv python install 3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to Semantic Versioning.
 
 ### Infrastructure
 
-- **CI and release workflows now use current Node.js 24-based action majors.** GitHub was forcibly running the older checkout, artifact, and uv setup actions under a compatibility runtime and warning that their Node.js 20 runtime was deprecated (#80).
+- **CI and release workflows now use current Node.js 24-based actions.** GitHub was forcibly running the older checkout, artifact, uv setup, coverage, and release-publishing actions under a compatibility runtime and warning that their Node.js 20 runtime was deprecated (#80).
+- **Parallel CI jobs now use distinct, reusable uv cache keys.** Matrix and specialist jobs previously raced to reserve the same cold-cache entry, producing failed-save annotations and duplicate upload work (#82).
 
 ## [0.4.2] - 2026-09-05
 


### PR DESCRIPTION
## Summary

- Upgrade Codecov to v6 so its transitive github-script dependency runs on Node.js 24.
- Give every Python matrix, specialist, and release job a stable distinct uv cache suffix.
- Prevent parallel cold-cache saves from contending while retaining reusable caches across runs.

Closes #82
Refs #80

## Verification

- Official Codecov v6 manifest pins github-script v8; its action metadata declares `node24`.
- Unique stable cache suffixes cover Python 3.11/3.12/3.13, test-packs, typecheck, and release.
- `.venv/bin/pytest -q` — 792 passed, 8 skipped.
- `uv run mypy graphlm --ignore-missing-imports` — clean across 31 source files.
- `git diff --check` — clean.
- Independent fresh-context review — approved with no findings.

## Post-merge

No deployment or package release is required. Confirm the next CI run contains neither Node.js 20 nor concurrent cache-save annotations.

🤖 Generated with [Codex](https://Codex.com/Codex)